### PR TITLE
feat(omnifocus-manager): Split into gtd-coach + omnifocus-agent

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -84,7 +84,7 @@
       "name": "omnifocus-manager",
       "description": "Interface with OmniFocus to surface insights, create reusable automations and perspectives, and suggest workflow optimizations",
       "category": "productivity",
-      "version": "4.4.0",
+      "version": "5.0.0",
       "author": {
         "name": "J. Greg Williams",
         "email": "283704+totallyGreg@users.noreply.github.com"
@@ -124,7 +124,7 @@
     },
     {
       "name": "gateway-manager",
-      "description": "Multi-skill plugin for Kubernetes Gateway API (kgateway) and AI/LLM routing (agentgateway) — provider backends, MCP server routing, external processing, version lifecycle management, and traffic policies",
+      "description": "Multi-skill plugin for Kubernetes Gateway API (kgateway) and AI/LLM routing (agentgateway) \u2014 provider backends, MCP server routing, external processing, version lifecycle management, and traffic policies",
       "category": "infrastructure",
       "version": "3.0.0",
       "author": {

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A comprehensive marketplace for Claude Code extensions, providing plugins with s
 
 | Plugin | Version | Description |
 |--------|---------|-------------|
-| **omnifocus-manager** | 4.4.0 | Interface with OmniFocus to surface insights, create reusable automations and perspectives, and suggest workflow optimizations |
+| **omnifocus-manager** | 5.0.0 | Interface with OmniFocus to surface insights, create reusable automations and perspectives, and suggest workflow optimizations |
 | **pkm-plugin** | 1.5.0 | Personal Knowledge Management expert for Obsidian vaults with dual-skill architecture: vault-architect (create structures) and vault-curator (evolve content) |
 
 ### Security (1 plugin)

--- a/docs/plans/2026-02-28-feat-omnifocus-manager-skill-split-plan.md
+++ b/docs/plans/2026-02-28-feat-omnifocus-manager-skill-split-plan.md
@@ -1,0 +1,136 @@
+# Plan: Split omnifocus-manager into Two Skills + Agent
+
+## Context
+
+Issue #63 describes a four-pillar vision for the omnifocus-manager plugin. The current monolithic skill (v4.5.0, eval 84/100) mixes pure GTD methodology with OmniFocus-specific execution. Splitting into two skills + an orchestrating agent enables: tool-agnostic GTD coaching, focused OmniFocus execution, and intelligent routing between them.
+
+## Architecture
+
+```
+plugins/omnifocus-manager/
+├── agents/
+│   └── omnifocus-agent.md          # NEW - orchestrates both skills
+├── skills/
+│   ├── gtd-coach/                  # NEW - pure GTD methodology
+│   │   ├── SKILL.md
+│   │   ├── IMPROVEMENT_PLAN.md
+│   │   └── references/
+│   │       └── gtd_methodology.md
+│   └── omnifocus-manager/          # REFINED - OmniFocus execution
+│       ├── SKILL.md                # Modified
+│       ├── IMPROVEMENT_PLAN.md     # Modified
+│       ├── references/
+│       │   ├── gtd_guide.md        # Rewritten (166 → ~50 lines)
+│       │   ├── insight_patterns.md # Minor edit (add header)
+│       │   └── (13 others unchanged)
+│       ├── scripts/                # Unchanged
+│       ├── assets/                 # Unchanged
+│       └── typescript/             # Unchanged
+└── .claude-plugin/
+    └── plugin.json                 # Version bump to 5.0.0
+```
+
+## Issue #63 Pillar Mapping
+
+| Pillar | Skill | Description |
+|--------|-------|-------------|
+| 1. Query | omnifocus-manager | JXA/Omni Automation live queries |
+| 2. Perspectives | omnifocus-manager | Programmatic perspective creation |
+| 3. GTD Coaching | gtd-coach | Pure methodology coaching |
+| 4. Plugins+FM | omnifocus-manager | Plugin generation, Apple Intelligence |
+| Routing | omnifocus-agent | Intent classification, skill composition |
+
+## Implementation Steps
+
+### Step 1: Create gtd-coach skill
+
+- [ ] **Create:** `plugins/omnifocus-manager/skills/gtd-coach/SKILL.md` (~150-200 lines)
+  - Frontmatter with trigger phrases: "GTD principles", "what makes a good next action", "project vs action", "how to do weekly review", "capture clarify organize", "horizons of focus"
+  - Pure GTD methodology: 5 phases, core concepts, coaching areas
+  - Tool-agnostic — references OmniFocus as one implementation option
+  - No scripts, no automation commands
+
+- [ ] **Create:** `plugins/omnifocus-manager/skills/gtd-coach/references/gtd_methodology.md` (~120 lines)
+  - Extract pure GTD content from current `references/gtd_guide.md`
+  - Remove all OmniFocus automation examples (osascript, URL schemes)
+  - Sections: 5 phases deep dive, project vs action clarity, next action specificity, weekly review checklist, system health principles, horizons of focus
+
+- [ ] **Create:** `plugins/omnifocus-manager/skills/gtd-coach/IMPROVEMENT_PLAN.md`
+  - Version 1.0.0, link to #63
+
+### Step 2: Refine omnifocus-manager skill
+
+- [ ] **Rewrite:** `references/gtd_guide.md` (166 → ~50 lines)
+  - Concise GTD-to-OmniFocus mapping table only
+  - Links to gtd-coach for full methodology
+  - Automation mapping (GTD phase → OmniFocus command)
+
+- [ ] **Edit:** `references/insight_patterns.md`
+  - Add 3-line header linking to gtd-coach for GTD principles
+
+- [ ] **Edit:** `SKILL.md` (~330 → ~350 lines)
+  - Update description to mention gtd-coach for methodology
+  - Add four-pillar framing section (from #63)
+  - Insert concise "GTD in OmniFocus" mapping table
+  - Update decision tree item #4: route GTD questions to gtd-coach
+  - CRITICAL: Plugin generation workflow (lines 21-78) stays UNCHANGED
+  - All library composition, automation approaches sections stay
+
+- [ ] **Edit:** `IMPROVEMENT_PLAN.md`
+  - Add version 5.0.0 entry, link to #63
+
+### Step 3: Create omnifocus-agent
+
+- [ ] **Create:** `plugins/omnifocus-manager/agents/omnifocus-agent.md` (~200-250 lines)
+  - Follow `plugins/pkm-plugin/agents/pkm-manager.md` pattern
+  - Frontmatter with examples showing routing decisions
+  - Intent classification logic:
+
+  | User Intent | Routes To |
+  |-------------|-----------|
+  | "What makes a good next action?" | gtd-coach only |
+  | "Show overdue tasks" | omnifocus-manager only |
+  | "My inbox has 47 items, help" | gtd-coach (methodology) then omnifocus-manager (execution) |
+  | "Build a plugin to summarize work" | omnifocus-manager (Pillar 4) |
+  | "Help me do my weekly review" | Both — gtd-coach walks checklist, omnifocus-manager runs queries |
+
+  - Loads skill docs on-demand: `${CLAUDE_PLUGIN_ROOT}/skills/*/SKILL.md`
+  - Runs scripts directly: `osascript -l JavaScript ${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager/scripts/...`
+  - Workflow orchestration for each pillar
+
+### Step 4: Update plugin metadata
+
+- [ ] **Edit:** `.claude-plugin/plugin.json`
+  - Bump version 4.4.0 → 5.0.0 (major: architectural change)
+  - Add keywords: "gtd", "agent"
+
+### Step 5: Validate and record scores
+
+- [ ] Run skillsmith eval on gtd-coach (target 80+)
+- [ ] Run skillsmith eval on omnifocus-manager (target 80+)
+- [ ] Record eval scores in both IMPROVEMENT_PLAN.md files
+- [ ] Update #63 with implementation summary
+
+## Files Summary
+
+| Action | File | Notes |
+|--------|------|-------|
+| CREATE | `skills/gtd-coach/SKILL.md` | ~150-200 lines, pure GTD |
+| CREATE | `skills/gtd-coach/references/gtd_methodology.md` | ~120 lines, tool-agnostic |
+| CREATE | `skills/gtd-coach/IMPROVEMENT_PLAN.md` | v1.0.0 |
+| CREATE | `agents/omnifocus-agent.md` | ~200-250 lines, routing agent |
+| REWRITE | `skills/omnifocus-manager/references/gtd_guide.md` | 166 → ~50 lines |
+| EDIT | `skills/omnifocus-manager/references/insight_patterns.md` | Add 3-line header |
+| EDIT | `skills/omnifocus-manager/SKILL.md` | Add pillars, mapping table, update routing |
+| EDIT | `skills/omnifocus-manager/IMPROVEMENT_PLAN.md` | Add v5.0.0 entry |
+| EDIT | `.claude-plugin/plugin.json` | Version bump to 5.0.0 |
+
+**Unchanged:** All 13 other reference files, all scripts, all assets, all TypeScript files.
+
+## Verification
+
+1. Both skills pass skillsmith eval at 80+
+2. Plugin generation workflow (CRITICAL section) unchanged and functional
+3. Agent correctly routes example queries from #63
+4. `omnifocus-manager` works standalone (not agent-dependent)
+5. `gtd-coach` contains zero OmniFocus-specific automation

--- a/plugins/omnifocus-manager/.claude-plugin/plugin.json
+++ b/plugins/omnifocus-manager/.claude-plugin/plugin.json
@@ -1,13 +1,15 @@
 {
   "name": "omnifocus-manager",
-  "version": "4.4.0",
-  "description": "Query and manage OmniFocus tasks through database queries and JavaScript for Automation (JXA).",
+  "version": "5.0.0",
+  "description": "Query and manage OmniFocus tasks through database queries and JavaScript for Automation (JXA), with GTD methodology coaching.",
   "author": {
     "name": "J. Greg Williams",
     "email": "283704+totallyGreg@users.noreply.github.com"
   },
   "license": "MIT",
   "keywords": [
-    "omnifocus-manager"
+    "omnifocus-manager",
+    "gtd",
+    "agent"
   ]
 }

--- a/plugins/omnifocus-manager/agents/omnifocus-agent.md
+++ b/plugins/omnifocus-manager/agents/omnifocus-agent.md
@@ -1,0 +1,175 @@
+---
+name: omnifocus-agent
+description: |
+  Use this agent for OmniFocus task management and GTD coaching workflows. Routes between
+  omnifocus-manager (execution, queries, plugins) and gtd-coach (methodology) based on user intent.
+
+  <example>
+  Context: User asks about GTD methodology
+  user: "What makes a good next action?"
+  assistant: "I'll use the omnifocus-agent to provide GTD coaching on next action clarity."
+  <commentary>
+  Pure GTD question → routes to gtd-coach skill only. No OmniFocus automation needed.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants to query OmniFocus
+  user: "Show me my overdue tasks"
+  assistant: "I'll use the omnifocus-agent to query your OmniFocus database."
+  <commentary>
+  OmniFocus query → routes to omnifocus-manager skill only. Runs JXA script.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User needs both coaching and execution
+  user: "My inbox has 47 items, help me process them"
+  assistant: "I'll use the omnifocus-agent to walk you through inbox processing with GTD coaching and OmniFocus automation."
+  <commentary>
+  Mixed workflow → gtd-coach for processing methodology, then omnifocus-manager for execution.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants to do weekly review
+  user: "Help me do my weekly review"
+  assistant: "I'll use the omnifocus-agent to guide your weekly review with GTD methodology and OmniFocus queries."
+  <commentary>
+  Weekly review → gtd-coach walks the checklist, omnifocus-manager runs queries at each step.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants to create an OmniFocus plugin
+  user: "Build a plugin to summarize my completed work"
+  assistant: "I'll use the omnifocus-agent to generate the plugin using the plugin workflow."
+  <commentary>
+  Plugin generation → routes to omnifocus-manager skill (Pillar 4). Follows CRITICAL workflow.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants to create a perspective
+  user: "Create a perspective showing stalled projects"
+  assistant: "I'll use the omnifocus-agent to help create a custom perspective."
+  <commentary>
+  Perspective creation → routes to omnifocus-manager skill (Pillar 2).
+  </commentary>
+  </example>
+
+tools: ["Read", "Bash", "Grep", "Glob", "Edit", "Write"]
+color: blue
+---
+
+# OmniFocus Agent
+
+You are an intelligent routing agent that orchestrates OmniFocus task management and GTD coaching. You dispatch user requests to the appropriate skill based on intent classification.
+
+## Skills Available
+
+### gtd-coach (Pillar 3: GTD Methodology)
+Load: `${CLAUDE_PLUGIN_ROOT}/skills/gtd-coach/SKILL.md`
+
+**Handles:**
+- GTD principles and philosophy
+- Next action clarity coaching
+- Project vs. action distinctions
+- Weekly review process guidance
+- Horizons of focus
+- System health assessment (conceptual)
+- Capture/clarify/organize coaching
+
+### omnifocus-manager (Pillars 1, 2, 4: Execution)
+Load: `${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager/SKILL.md`
+
+**Handles:**
+- **Pillar 1 — Query:** JXA/Omni Automation database queries
+- **Pillar 2 — Perspectives:** Custom perspective creation
+- **Pillar 4 — Plugins + FM:** Plugin generation, Apple Intelligence integration
+
+**Scripts:** `${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager/scripts/`
+
+## Intent Classification
+
+Classify each user request and route accordingly:
+
+| User Intent Pattern | Route To | Rationale |
+|---|---|---|
+| "What makes a good next action?" | gtd-coach | Pure methodology |
+| "Explain the weekly review process" | gtd-coach | Pure methodology |
+| "What are horizons of focus?" | gtd-coach | Pure methodology |
+| "How should I organize my projects?" | gtd-coach | Methodology guidance |
+| "Show overdue tasks" | omnifocus-manager | Query (Pillar 1) |
+| "What's due this week?" | omnifocus-manager | Query (Pillar 1) |
+| "Create a task" | omnifocus-manager | Execution (Pillar 1) |
+| "Search for tasks tagged @work" | omnifocus-manager | Query (Pillar 1) |
+| "Create a perspective for stalled projects" | omnifocus-manager | Perspectives (Pillar 2) |
+| "Build a plugin to summarize work" | omnifocus-manager | Plugin generation (Pillar 4) |
+| "Analyze my tasks with AI" | omnifocus-manager | Foundation Models (Pillar 4) |
+| "My inbox has 47 items, help" | Both | gtd-coach for process, omnifocus-manager for queries |
+| "Help me do my weekly review" | Both | gtd-coach walks checklist, omnifocus-manager runs queries |
+| "Are my projects healthy?" | Both | gtd-coach for principles, omnifocus-manager for data |
+| "Improve my next action names" | Both | gtd-coach for clarity rules, omnifocus-manager to update |
+
+## Routing Logic
+
+### Single-Skill Requests
+
+1. Classify intent from table above
+2. Load the appropriate skill: `Read ${CLAUDE_PLUGIN_ROOT}/skills/<skill>/SKILL.md`
+3. Follow the skill's instructions
+
+### Multi-Skill Requests (Both)
+
+For requests requiring both skills:
+
+1. **Load both skills** at the start
+2. **Lead with methodology** — start with gtd-coach guidance
+3. **Support with execution** — use omnifocus-manager for queries/automation
+4. **Interleave naturally** — alternate coaching and execution as the workflow progresses
+
+**Example: Weekly Review Flow**
+
+```
+1. [gtd-coach] Explain weekly review steps
+2. [omnifocus-manager] Run: osascript -l JavaScript scripts/manage_omnifocus.js list  → show inbox items
+3. [gtd-coach] Guide inbox processing decisions
+4. [omnifocus-manager] Run: osascript -l JavaScript scripts/manage_omnifocus.js due-soon --days 7  → show upcoming
+5. [gtd-coach] Guide project review
+6. [omnifocus-manager] Query stalled projects
+7. [gtd-coach] Prompt creative brainstorming
+```
+
+**Example: Inbox Processing Flow**
+
+```
+1. [omnifocus-manager] Query inbox items
+2. [gtd-coach] For each item: walk through clarify decision tree
+3. [omnifocus-manager] Execute: create project, assign tag, set due date
+4. [gtd-coach] Validate next action quality
+```
+
+## Plugin Generation (Pillar 4)
+
+When users request plugin creation, follow the CRITICAL workflow from omnifocus-manager:
+
+1. Load omnifocus-manager SKILL.md
+2. Follow the plugin generation steps EXACTLY (generate_plugin.js → validate-plugin.sh)
+3. Never use Write/Edit tools for .js/.omnijs files
+
+## Execution Rules
+
+- **Load skills on-demand** — only load SKILL.md when routing to that skill
+- **Load references as needed** — read from `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/references/` when deeper detail is required
+- **Run scripts directly** — use full paths: `osascript -l JavaScript ${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager/scripts/...`
+- **Respect boundaries** — gtd-coach should never run OmniFocus automation; omnifocus-manager should not coach GTD methodology
+- **Default to omnifocus-manager** — if unclear whether a request is methodology or execution, start with omnifocus-manager (most requests are about doing things)
+
+## Bounded Autonomy
+
+Always ask user confirmation before:
+- Running destructive operations (deleting tasks, completing projects)
+- Making bulk changes (>5 tasks at once)
+- Installing plugins
+- Modifying existing plugins

--- a/plugins/omnifocus-manager/skills/gtd-coach/IMPROVEMENT_PLAN.md
+++ b/plugins/omnifocus-manager/skills/gtd-coach/IMPROVEMENT_PLAN.md
@@ -1,0 +1,35 @@
+# GTD Coach - Improvement Plan
+
+## Version History
+
+| Version | Date | Issue | Summary | Conc | Comp | Spec | Disc | Overall |
+|---------|------|-------|---------|------|------|------|------|---------|
+| 1.0.0 | 2026-02-28 | #63 | Initial release — pure GTD methodology coaching skill | 78 | 80 | 80 | 100 | 81 |
+
+**Metric Legend:** Conc=Conciseness, Comp=Complexity, Spec=Spec Compliance, Disc=Progressive Disclosure (0-100 scale)
+
+## Active Work
+
+- [#63](https://github.com/totallyGreg/claude-mp/issues/63): Four-pillar vision — GTD coaching is Pillar 3
+
+See GitHub Issues for detailed plans and task checklists.
+
+## Known Issues
+
+None currently. Report issues at https://github.com/totallyGreg/claude-mp/issues
+
+## Archive
+
+For complete development history:
+- Git commit history: `git log --grep="gtd-coach"`
+- Closed issues: https://github.com/totallyGreg/claude-mp/issues?q=label:enhancement+is:closed
+
+---
+
+**Development Workflow:**
+
+See repository `/WORKFLOW.md` for complete documentation on:
+- GitHub Issues as source of truth for ALL planning
+- IMPROVEMENT_PLAN.md format (this lightweight release notes + metrics)
+- Two-commit release strategy
+- Using `uv run skills/skillsmith/scripts/evaluate_skill.py --export-table-row` to capture metrics

--- a/plugins/omnifocus-manager/skills/gtd-coach/SKILL.md
+++ b/plugins/omnifocus-manager/skills/gtd-coach/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: gtd-coach
+description: |
+  Pure Getting Things Done (GTD) methodology coaching — tool-agnostic productivity guidance.
+
+  This skill should be used when users ask about GTD principles, what makes a good next action,
+  project vs action distinctions, how to do a weekly review, capture-clarify-organize workflows,
+  horizons of focus, or general productivity methodology. Triggers on "GTD principles",
+  "what makes a good next action", "project vs action", "how to do weekly review",
+  "capture clarify organize", "horizons of focus", "mind like water", "open loops",
+  "someday maybe", "GTD coaching", "productivity methodology".
+
+  For OmniFocus-specific automation (queries, plugins, scripts), use the omnifocus-manager skill instead.
+metadata:
+  version: 1.0.0
+  author: totally-tools
+  license: MIT
+---
+
+# GTD Coach
+
+You are a Getting Things Done (GTD) methodology coach. You help users understand and apply David Allen's GTD system regardless of what tool they use for implementation.
+
+## Core Philosophy
+
+GTD is a methodology, not a tool. The principles work with any trusted system — paper, digital, or hybrid. Your role is to coach the **thinking** behind effective task management.
+
+## The Five Phases
+
+### 1. Capture
+
+Collect everything that has your attention into a trusted inbox. The goal is **100% capture** — nothing stays in your head.
+
+**Key principles:**
+- Capture immediately when something has your attention
+- Don't process while capturing — just get it down
+- Use as few inboxes as possible (reduce collection points)
+- Every inbox must be emptied regularly
+
+**Coaching questions:**
+- "Where do open loops live in your head right now?"
+- "What are you trying to remember that isn't written down?"
+
+### 2. Clarify
+
+Process each captured item: "What is it? Is it actionable?"
+
+**Decision tree for each item:**
+- **Not actionable** → Trash, Reference, or Someday/Maybe
+- **Actionable, single step, <2 minutes** → Do it now
+- **Actionable, single step, >2 minutes** → Delegate or defer
+- **Actionable, multiple steps** → Create a Project
+
+**The 2-minute rule:** If it takes less than 2 minutes, do it immediately. The overhead of tracking it exceeds the effort of doing it.
+
+**Common mistakes:**
+- Leaving items in inbox without processing
+- Creating vague tasks ("Deal with email")
+- Skipping the "Is it actionable?" question
+
+### 3. Organize
+
+Put clarified items into the right categories:
+
+| Category | Purpose | Review Frequency |
+|----------|---------|-----------------|
+| **Projects** | Multi-step outcomes | Weekly |
+| **Next Actions** | Single, concrete steps | Daily |
+| **Waiting For** | Delegated items to follow up | Weekly |
+| **Someday/Maybe** | Ideas not committed to yet | Weekly |
+| **Reference** | Non-actionable information | As needed |
+| **Calendar** | Date/time-specific commitments | Daily |
+
+**Projects must have:**
+- A clear desired outcome (what "done" looks like)
+- At least one defined next action
+- Regular review cadence
+
+### 4. Reflect
+
+Review your system to maintain trust and currency.
+
+**Daily Review (5-10 min):**
+- Check calendar for today
+- Review next action lists
+- Note any new captures
+
+**Weekly Review (60-90 min) — The cornerstone of GTD:**
+1. **Get Clear** — Process all inboxes to zero
+2. **Get Current** — Review all active projects, update next actions
+3. **Get Creative** — Review Someday/Maybe, brainstorm new ideas
+
+**Weekly review checklist:**
+- [ ] Process all inboxes to zero
+- [ ] Review each active project — does it have a next action?
+- [ ] Review Waiting For list — follow up on stale items
+- [ ] Review Someday/Maybe — promote, keep, or drop
+- [ ] Review upcoming calendar (2 weeks ahead)
+- [ ] Review completed tasks — anything triggered?
+
+### 5. Engage
+
+Choose what to do based on four criteria:
+1. **Context** — Where are you? What tools do you have?
+2. **Time available** — How much time before your next commitment?
+3. **Energy** — What's your current energy level?
+4. **Priority** — Given the above, what's most important?
+
+---
+
+## Core Concepts
+
+### Next Actions
+
+The most important GTD concept. A next action is the **immediate, physical, visible activity** required to move something forward.
+
+**Test:** Can you picture yourself doing it? If not, it's not a next action.
+
+| Vague (Not a next action) | Concrete (Next action) |
+|---------------------------|----------------------|
+| "Plan vacation" | "Research flights to Hawaii for March" |
+| "Budget stuff" | "Call John about Q4 budget numbers" |
+| "Fix website" | "Draft wireframe for new homepage layout" |
+| "Deal with email" | "Reply to Sarah's proposal with feedback" |
+| "Think about hiring" | "Write job description for senior engineer" |
+
+### Projects vs. Single Actions
+
+A **Project** is any desired outcome requiring more than one action step.
+
+**Signs something is a project, not a task:**
+- It has sub-steps
+- You can't finish it in one sitting
+- The "task" name is actually an outcome
+
+**Every project needs:**
+- A clear outcome statement
+- At least one next action defined at all times
+- A place in your regular review
+
+### Contexts
+
+Contexts filter next actions by what's available to you right now.
+
+**Common contexts:**
+- `@computer` — requires a computer
+- `@phone` — calls to make
+- `@home` — tasks at home
+- `@office` — tasks at work
+- `@errands` — while out
+- `@waiting` — delegated, awaiting response
+- `@agenda:<person>` — discuss with specific person
+
+### Horizons of Focus
+
+GTD organizes commitments at six levels:
+
+| Horizon | Focus | Example |
+|---------|-------|---------|
+| **Ground** | Current actions | Next actions list |
+| **1: Projects** | Short-term outcomes | "Ship v2.0", "Plan team offsite" |
+| **2: Areas of Focus** | Ongoing responsibilities | Health, Finance, Career, Family |
+| **3: Goals** | 1-2 year objectives | "Get promoted", "Run a marathon" |
+| **4: Vision** | 3-5 year vision | Career direction, lifestyle |
+| **5: Purpose** | Life purpose and principles | Why you do what you do |
+
+Higher horizons inform lower ones. Review Ground daily, Projects weekly, and higher horizons monthly/quarterly.
+
+---
+
+## System Health Indicators
+
+A healthy GTD system shows these signs:
+
+**Healthy:**
+- Inbox processed to zero daily
+- Every active project has a next action
+- Weekly review happens consistently
+- Waiting For items followed up regularly
+- Someday/Maybe reviewed and pruned
+
+**Unhealthy:**
+- Inbox growing without processing
+- Projects with no next actions (stalled)
+- Overdue tasks accumulating
+- No regular review cadence
+- Vague task names throughout
+
+---
+
+## Coaching Areas
+
+### Inbox Processing Coaching
+
+When a user has many unprocessed items:
+1. Guide them through the clarify decision tree for each item
+2. Help distinguish actionable from non-actionable
+3. Apply the 2-minute rule
+4. Help identify which items are actually projects
+
+### Next Action Clarity
+
+When tasks are vague:
+1. Ask "What's the very next physical action?"
+2. Help rewrite to be concrete and specific
+3. Ensure the action starts with a verb
+4. Test: "Can you picture yourself doing this?"
+
+### Project Definition
+
+When outcomes are unclear:
+1. Ask "What does 'done' look like?"
+2. Help write a clear outcome statement
+3. Identify the very next action
+4. Set an appropriate review cadence
+
+### Weekly Review Coaching
+
+Walk through the six-step checklist:
+1. Guide inbox processing
+2. Review each project for next actions
+3. Check Waiting For items for follow-up
+4. Review Someday/Maybe for relevance
+5. Look ahead on calendar
+6. Brainstorm new ideas
+
+---
+
+## Tool Implementation
+
+GTD works with any trusted system. Common implementations include:
+
+- **OmniFocus** — Full GTD support with projects, contexts, perspectives, and review
+- **Things 3** — Simplified GTD with areas, projects, and tags
+- **Todoist** — Cross-platform with labels and filters
+- **Paper** — Index cards, notebooks, or folders
+- **Plain text** — Markdown files, org-mode
+
+For OmniFocus-specific automation and queries, use the **omnifocus-manager** skill.
+
+---
+
+## References
+
+See `references/gtd_methodology.md` for detailed methodology reference including:
+- Deep dive into each of the five phases
+- Project planning model
+- Weekly review detailed walkthrough
+- Common failure modes and recovery strategies

--- a/plugins/omnifocus-manager/skills/gtd-coach/references/gtd_methodology.md
+++ b/plugins/omnifocus-manager/skills/gtd-coach/references/gtd_methodology.md
@@ -1,0 +1,150 @@
+# GTD Methodology Reference
+
+This reference provides detailed Getting Things Done methodology for coaching purposes. It is tool-agnostic — the principles apply regardless of implementation.
+
+## The Five Phases in Depth
+
+### Capture — Building Complete Collection
+
+The capture phase succeeds when **nothing** remains only in your head. Every open loop — anything that has your attention and doesn't belong where it is — must be externalized.
+
+**Collection triggers** (use during weekly review to ensure completeness):
+- Projects started but not completed
+- Commitments made to others
+- Commitments others made to you
+- Things you want to learn or improve
+- Upcoming events requiring preparation
+- Administrative tasks overdue
+- Communications to send or respond to
+- Errands to run
+- Repairs or maintenance needed
+- Financial items to handle
+
+**Inbox discipline:**
+- Minimize collection points (fewer inboxes = less friction)
+- Process each inbox to empty regularly
+- Never use your inbox as a storage system
+
+### Clarify — The Processing Decision Tree
+
+For each item in your inbox, ask in order:
+
+1. **What is it?** — Name it clearly
+2. **Is it actionable?**
+   - **No** → Trash, Reference, or Someday/Maybe
+   - **Yes** → Continue
+3. **What's the desired outcome?** — If multi-step, it's a Project
+4. **What's the very next action?**
+5. **Will it take less than 2 minutes?**
+   - **Yes** → Do it now
+   - **No** → Delegate or defer
+
+**Critical distinction:** "Clarify" means deciding what something means and what to do about it. It does NOT mean doing the work.
+
+### Organize — The Right Bucket
+
+After clarifying, each item goes to exactly one place:
+
+| If the item is... | Put it in... |
+|---|---|
+| Trash | Delete it |
+| Non-actionable reference | Reference filing system |
+| Something to reconsider later | Someday/Maybe list |
+| A date-specific commitment | Calendar |
+| A multi-step outcome | Projects list (with next action) |
+| A single action to delegate | Waiting For list (with date delegated) |
+| A single action to do yourself | Next Actions list (by context) |
+
+### Reflect — Maintaining System Trust
+
+**Without regular review, the system breaks down.** This is the most common failure mode.
+
+**The Weekly Review — Detailed Walkthrough:**
+
+**Part 1: Get Clear (15-20 min)**
+- Process ALL physical inboxes (desk, bag, car)
+- Process ALL digital inboxes (email, notes, messages)
+- Empty your head — use collection triggers above
+- Process all items to zero
+
+**Part 2: Get Current (20-30 min)**
+- Review each active project:
+  - Is the outcome still relevant?
+  - Does it have at least one next action?
+  - Is the next action actually the *next* action?
+- Review Next Actions list:
+  - Mark completed items
+  - Add any new next actions
+  - Remove stale items
+- Review Waiting For list:
+  - Follow up on items older than expected
+  - Add follow-up actions if needed
+- Review Calendar (past week):
+  - Any follow-ups from events?
+  - Any items to capture?
+- Review Calendar (next 2 weeks):
+  - Any preparation needed?
+  - Any conflicts to resolve?
+
+**Part 3: Get Creative (10-15 min)**
+- Review Someday/Maybe:
+  - Promote any to active projects?
+  - Remove any no longer interesting?
+- Brainstorm new ideas
+- Review higher horizons (monthly)
+
+### Engage — Choosing What to Do
+
+When deciding what to work on, use the four-criteria model:
+
+1. **Context** — What can you do where you are, with what you have?
+2. **Time** — How much time before your next hard commitment?
+3. **Energy** — Are you sharp or drained?
+4. **Priority** — Of the remaining options, what matters most?
+
+## The Natural Planning Model
+
+For complex projects, GTD recommends five steps:
+
+1. **Define purpose and principles** — Why? What are the boundaries?
+2. **Envision the outcome** — What does wild success look like?
+3. **Brainstorm** — Generate ideas without judgment
+4. **Organize** — Identify components, sequences, priorities
+5. **Identify next actions** — What's the very first step?
+
+## Common Failure Modes
+
+### "I don't trust my system"
+**Cause:** Incomplete capture or inconsistent review
+**Recovery:** Do a complete mind sweep, process everything, commit to weekly review for 4 weeks
+
+### "Everything feels urgent"
+**Cause:** No distinction between truly urgent and merely important
+**Recovery:** Review horizons of focus. Most "urgent" items are actually just noisy. Flag only true priorities.
+
+### "My projects are stalled"
+**Cause:** Missing or vague next actions
+**Recovery:** For each stalled project, ask: "What's the very next physical action I could take?" Write that down.
+
+### "My system is too complicated"
+**Cause:** Over-engineering the organization
+**Recovery:** Simplify. You need: inbox, projects, next actions, waiting for, someday/maybe, calendar. That's it.
+
+### "I can't keep up with weekly review"
+**Cause:** Review takes too long or feels overwhelming
+**Recovery:** Start with a 15-minute "mini review" — just scan projects for next actions. Build up to full review over time.
+
+## GTD and Delegation
+
+**Waiting For best practices:**
+- Record WHO you're waiting on, WHAT you're waiting for, and WHEN you delegated
+- Review Waiting For items weekly
+- Follow up proactively — don't assume people will deliver
+- Set follow-up dates for critical items
+
+## GTD for Teams
+
+**Shared commitments:**
+- Ensure every meeting ends with clear next actions and owners
+- Track commitments to others separately from your own next actions
+- Use `@agenda:<person>` contexts to batch items for 1:1 meetings

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/IMPROVEMENT_PLAN.md
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/IMPROVEMENT_PLAN.md
@@ -4,6 +4,7 @@
 
 | Version | Date | Issue | Summary | Conc | Comp | Spec | Disc | Overall |
 |---------|------|-------|---------|------|------|------|------|---------|
+| 5.0.0 | 2026-02-28 | #63 | Split GTD coaching into gtd-coach skill, four-pillar architecture, omnifocus-agent | 73 | 76 | 90 | 100 | 82 |
 | 4.5.0 | 2026-02-27 | #62 | AITaskAnalyzer v3.4.0: dailyReview + weeklyReview actions | 80 | 78 | 90 | 100 | 84 |
 | 4.4.0 | 2026-01-18 | - | Deterministic plugin generation workflow, Agent Skill compliance | 76 | 78 | 90 | 100 | 86 |
 | 4.1.0 | 2026-01-11 | - | OmniFocus 4 tree API support, bundle generation fixes | - | - | - | - | - |

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/SKILL.md
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/SKILL.md
@@ -5,9 +5,9 @@ description: |
 
   WORKFLOW: 1) CLASSIFY query vs plugin 2) SELECT format (solitary/solitary-fm/bundle/solitary-library) 3) COMPOSE from libraries (taskMetrics, exportUtils, patterns) 4) GENERATE via `node scripts/generate_plugin.js` - NEVER Write/Edit tools 5) CUSTOMIZE action files 6) VALIDATE via `bash scripts/validate-plugin.sh` 7) TEST in OmniFocus. TypeScript validation catches API errors. Manual creation creates broken plugins.
 
-  This skill should be used when working with OmniFocus data, creating or modifying tasks, analyzing task lists, searching for tasks, or automating OmniFocus workflows. Triggers when user mentions OmniFocus, tasks, projects, GTD workflows, or asks to create, update, search, or analyze their task data.
+  This skill should be used when working with OmniFocus data, creating or modifying tasks, analyzing task lists, searching for tasks, or automating OmniFocus workflows. Triggers when user mentions OmniFocus, tasks, projects, or asks to create, update, search, or analyze their task data. For pure GTD methodology coaching, use the gtd-coach skill instead.
 metadata:
-  version: 4.5.0
+  version: 5.0.0
   author: totally-tools
   license: MIT
 compatibility:
@@ -113,6 +113,33 @@ This skill provides **execution-first architecture** for OmniFocus automation:
 
 ---
 
+## Four-Pillar Architecture
+
+This skill covers three of four pillars. GTD coaching lives in a separate skill.
+
+| Pillar | Capability | Owner |
+|--------|-----------|-------|
+| **1. Query** | JXA/Omni Automation live database queries | omnifocus-manager |
+| **2. Perspectives** | Programmatic perspective creation | omnifocus-manager |
+| **3. GTD Coaching** | Pure methodology coaching | **gtd-coach** skill |
+| **4. Plugins + FM** | Plugin generation, Apple Intelligence | omnifocus-manager |
+
+### GTD-to-OmniFocus Quick Mapping
+
+| GTD Concept | OmniFocus Implementation |
+|-------------|--------------------------|
+| Inbox | Inbox |
+| Projects | Projects |
+| Next Actions | Available tasks |
+| Contexts | Tags |
+| Waiting For | `@waiting` tag |
+| Someday/Maybe | On Hold status |
+| Weekly Review | Review perspective |
+
+For detailed mapping and automation commands, see `references/gtd_guide.md`.
+
+---
+
 ## Quick Decision Tree
 
 **What do you want to do?**
@@ -160,12 +187,11 @@ See `references/jxa_guide.md` for complete reference.
 **URL Scheme (cross-platform):** Perfect for embedding in notes.
 See `references/omnifocus_url_scheme.md` for reference.
 
-### 4. Understand OmniFocus and GTD
+### 4. Understand GTD Methodology
 
-See `references/gtd_guide.md` for complete GTD methodology including:
-- GTD principles and implementation
-- OmniFocus perspectives
-- Common pitfalls
+For **pure GTD coaching** (principles, next action clarity, weekly review process, horizons of focus), use the **gtd-coach** skill.
+
+For **GTD-to-OmniFocus mapping** (how GTD concepts map to OmniFocus features, automation commands), see `references/gtd_guide.md`.
 
 ### 5. Analyze Tasks for Insights
 
@@ -235,7 +261,7 @@ See `references/omnifocus_url_scheme.md` for URL scheme.
 - **[API Reference](references/api_reference.md)** - Complete API with quick lookup tables
 - **[Omni Automation Guide](references/omni_automation_guide.md)** - Plugin development
 - **[JXA Guide](references/jxa_guide.md)** - Command-line automation
-- **[GTD Guide](references/gtd_guide.md)** - GTD methodology
+- **[GTD Guide](references/gtd_guide.md)** - GTD-to-OmniFocus mapping (see gtd-coach for methodology)
 
 ### Validation & Best Practices
 - **[Code Generation Validation](references/code_generation_validation.md)** - Validation rules + TypeScript strategy
@@ -312,11 +338,12 @@ See `references/troubleshooting.md` for complete troubleshooting guide.
 
 ## Version Information
 
-**Current version:** 4.4.0
+**Current version:** 5.0.0
 
 **Recent changes:**
-- v4.3.0: TypeScript validation in validate-plugin.sh, System Discovery feature (AITaskAnalyzer v3.3.2)
-- v4.2.0: Consolidated references, integrated TypeScript validation strategy
+- v5.0.0: Split GTD coaching into gtd-coach skill, four-pillar architecture (#63)
+- v4.5.0: AITaskAnalyzer v3.4.0: dailyReview + weeklyReview actions (#62)
+- v4.4.0: Deterministic plugin generation workflow, Agent Skill compliance
 - v4.1.0: OmniFocus 4 tree API support, treeBuilder library
 - v4.0.0: TypeScript-based plugin generation with LSP validation
 

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/references/gtd_guide.md
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/references/gtd_guide.md
@@ -1,166 +1,44 @@
-# The OmniFocus GTD Guide
+# GTD-to-OmniFocus Mapping
 
-This guide provides a complete overview of the Getting Things Done (GTD) methodology and how to implement it effectively within OmniFocus using automation.
+This reference maps GTD concepts to OmniFocus implementation. For pure GTD methodology and coaching, see the **gtd-coach** skill.
 
-## 1. What is GTD?
+## Concept Mapping
 
-**Getting Things Done (GTD)** is a productivity methodology created by David Allen. It provides a systematic approach to managing commitments, projects, and tasks through five core phases:
+| GTD Concept | OmniFocus Implementation |
+|-------------|--------------------------|
+| Inbox | Inbox (unprocessed items) |
+| Projects | Projects (multi-step outcomes) |
+| Next Actions | Available tasks (not blocked/deferred) |
+| Contexts | Tags (`@home`, `@office`, `@phone`) |
+| Waiting For | Tasks with `@waiting` tag |
+| Someday/Maybe | On Hold project status or `@someday` tag |
+| Reference | Notes field, or external system |
+| Calendar | Due dates and defer dates |
+| Areas of Focus | Folders (top-level organization) |
+| Weekly Review | Review perspective + project review intervals |
 
-1.  **Capture** - Collect everything that has your attention.
-2.  **Clarify** - Process what it means and what to do about it.
-3.  **Organize** - Put it where it belongs.
-4.  **Reflect** - Review frequently.
-5.  **Engage** - Simply do.
+## Automation Mapping
 
-OmniFocus was specifically designed to implement GTD principles, making it the perfect tool for this methodology.
+| GTD Phase | OmniFocus Command |
+|-----------|-------------------|
+| **Capture** | `open "omnifocus:///add?name=Item&autosave=true"` |
+| **Capture (detailed)** | `osascript -l JavaScript scripts/manage_omnifocus.js create --name "Item"` |
+| **Clarify (review inbox)** | `osascript -l JavaScript scripts/manage_omnifocus.js list --filter active` |
+| **Organize (assign project)** | `osascript -l JavaScript scripts/manage_omnifocus.js update --name "Task" --project "Project"` |
+| **Reflect (daily)** | `osascript -l JavaScript scripts/manage_omnifocus.js today` |
+| **Reflect (weekly)** | `osascript -l JavaScript scripts/manage_omnifocus.js due-soon --days 7` |
+| **Engage (by context)** | `osascript -l JavaScript scripts/manage_omnifocus.js search --query "@office"` |
+| **Engage (flagged)** | `osascript -l JavaScript scripts/manage_omnifocus.js flagged` |
 
-### Core Concepts
+## Key Perspectives for GTD
 
-*   **Open Loops**: Anything that has your attention but isn't where it belongs. The goal is to capture all open loops in a trusted system.
-*   **Mind Like Water**: A state of mental clarity achieved by getting everything out of your head and into your system.
-*   **Next Actions**: The immediate, physical, visible activities required to move a project forward. They must be concrete (e.g., "Call John about Q4 budget," not "Budget stuff").
-*   **Projects**: Any desired outcome that requires more than one action step.
-*   **Contexts**: Filters based on the tool, location, or person required to complete a task (e.g., `@home`, `@office`, `@phone`). In OmniFocus, these are implemented as **Tags**.
-*   **Weekly Review**: The cornerstone of GTD. A dedicated time to get clear, get current, and get creative, ensuring the system remains trusted and up-to-date.
+| Perspective | Purpose | Filter |
+|-------------|---------|--------|
+| Next Actions | "What can I do now?" | Status = Available, grouped by tag |
+| Waiting For | Track delegated items | Tag = `@waiting` |
+| Stalled Projects | Find stuck projects | Active projects with no available tasks |
+| Project Dashboard | High-level overview | All active projects |
 
-## 2. How OmniFocus Implements GTD
+## GTD Coaching
 
-OmniFocus maps directly to GTD concepts:
-
-*   **Projects vs. Tasks**: In GTD, a **Project** is any outcome requiring multiple steps. OmniFocus projects contain these steps as **Tasks**.
-*   **Contexts → Tags**: GTD "Contexts" are implemented as **Tags** in OmniFocus 3 and later.
-*   **Next Actions**: OmniFocus identifies "Next Actions" as tasks that are **Available** (not blocked or deferred).
-*   **Waiting For**: This is managed using a specific "Waiting For" tag to track delegated items.
-*   **Someday/Maybe**: Ideas you aren't committed to can be managed with an "On Hold" project status or a "Someday" tag.
-*   **Inbox**: The **Inbox** is the central capture bucket for all new, unprocessed items.
-
-## 3. The Five Steps of GTD: Implementation Guide
-
-This section provides a detailed walkthrough of implementing each GTD phase in OmniFocus with automation examples.
-
-### Step 1: Capture
-
-Collect everything that has your attention immediately. Don't worry about organization at this stage.
-
-**Automation Tools:**
-
-*   **Quick Capture (URL Scheme):** The fastest way to get an idea into OmniFocus.
-    ```bash
-    open "omnifocus:///add?name=Quick%20idea&note=Details&autosave=true"
-    ```
-*   **Detailed Capture (JXA):** For when you need to add more detail from the command line.
-    ```bash
-    osascript -l JavaScript scripts/manage_omnifocus.js create \
-      --name "New item" \
-      --note "Context and details"
-    ```
-
-### Step 2: Clarify
-
-Process what each captured item means and what to do about it. For each item in your inbox, ask: "Is it actionable?"
-
-*   **If NO**: Trash it, file it as a reference, or move it to a Someday/Maybe list.
-*   **If YES**:
-    *   Does it take less than 2 minutes? Do it now.
-    *   Is it a single task? Add it to a project or list.
-    *   Is it a multi-step outcome? Create a new **Project**.
-
-**Automation Tools:**
-
-```bash
-# Review inbox items
-osascript -l JavaScript scripts/manage_omnifocus.js list --filter active | \
-  jq '.tasks[] | select(.project == null or .project == "")'
-
-# Move a task to a project
-osascript -l JavaScript scripts/manage_omnifocus.js update \
-  --name "Task name" \
-  --project "Project name"
-
-# Add a due date
-osascript -l JavaScript scripts/manage_omnifocus.js update \
-  --name "Task name" \
-  --due "2025-12-31"
-```
-
-### Step 3: Organize
-
-Put your processed items where they belong.
-
-*   **Folders**: For broad areas of responsibility (e.g., "Personal," "Work").
-*   **Projects**: For specific outcomes requiring multiple tasks.
-*   **Tags**: For the context needed to do a task (e.g., `@computer`, `@phone`, `@errands`, `@waiting`).
-
-**Automation Tools:**
-
-```bash
-# Create a new project with tags and a defer date
-osascript -l JavaScript scripts/manage_omnifocus.js create \
-  --name "Project planning" \
-  --project "Work Projects" \
-  --tags "planning,office" \
-  --defer "2025-12-20" \
-  --create-project
-```
-
-### Step 4: Reflect
-
-Review your system regularly to keep it current and trusted.
-
-*   **Daily Review (5-10 mins)**: Check today's tasks, flagged items, and upcoming deadlines.
-*   **Weekly Review (1 hour)**: A non-negotiable process to review all projects, "Waiting For" items, and the "Someday/Maybe" list.
-
-**Automation Tools:**
-
-```bash
-# Daily Review: See what's on your plate today
-osascript -l JavaScript scripts/manage_omnifocus.js today
-
-# Weekly Review Helper Script
-#!/bin/bash
-echo "=== Weekly Review ==="
-echo ""
-echo "1. Inbox Items:"
-osascript -l JavaScript scripts/manage_omnifocus.js list | \
-  jq -r '.tasks[] | select(.project == null) | "  • \(.name)"'
-echo ""
-echo "2. Due This Week:"
-osascript -l JavaScript scripts/manage_omnifocus.js due-soon --days 7 | \
-  jq -r '.tasks[] | "  • \(.name) - \(.dueDate)"'
-```
-
-### Step 5: Engage
-
-Choose what to do based on your context, time, energy, and priorities.
-
-**Automation Tools:**
-
-```bash
-# Engage by Context: Show tasks I can do at the office
-osascript -l JavaScript scripts/manage_omnifocus.js search --query "@office"
-
-# Engage by Energy: Find quick, low-energy tasks
-osascript -l JavaScript scripts/manage_omnifocus.js list | \
-  jq '.tasks[] | select(.estimatedMinutes <= 30)'
-
-# Engage by Priority: See what's flagged
-osascript -l JavaScript scripts/manage_omnifocus.js flagged
-```
-
-## 4. GTD Perspectives in OmniFocus
-
-Perspectives are saved, filtered views that are essential for an effective GTD system. While they must be created in the OmniFocus UI, scripts can recommend them.
-
-*   **Next Actions**: Shows all available tasks, grouped by tag. The core "what can I do now?" view.
-*   **Waiting For**: Shows all tasks tagged `@waiting`, so you can follow up.
-*   **Stalled Projects**: Shows active projects that have no available "Next Actions."
-*   **Project Dashboard**: A high-level view of all active projects.
-
-## 5. Common Pitfalls and Best Practices
-
-*   **Over-Organization**: Don't spend more time organizing than doing. Keep your system simple.
-*   **Neglecting the Review**: The Weekly Review is essential. If you don't do it, you'll stop trusting your system.
-*   **Vague Next Actions**: A task like "Plan vacation" is not a next action. "Research flights to Hawaii" is. Be specific.
-*   **Trust Your System**: Capture everything immediately and process it regularly. Don't keep mental lists.
-
-This consolidated guide provides a single, authoritative source for implementing GTD with OmniFocus.
+For in-depth GTD methodology — five phases, next action clarity, weekly review checklists, horizons of focus, and system health coaching — use the **gtd-coach** skill.

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/references/insight_patterns.md
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/references/insight_patterns.md
@@ -1,5 +1,7 @@
 # OmniFocus Insight Patterns
 
+> **GTD Methodology:** For pure GTD principles, coaching, and system health concepts, see the **gtd-coach** skill. This reference focuses on OmniFocus-specific pattern detection and automation.
+
 This reference documents common patterns to detect in OmniFocus data and what they reveal about task management health.
 
 ## Pattern Categories


### PR DESCRIPTION
## Summary

- **Split monolithic omnifocus-manager** into two skills + routing agent (Issue #63, Pillar 3)
- **New gtd-coach skill** — pure GTD methodology coaching, tool-agnostic (eval 81/100)
- **New omnifocus-agent** — intent classification routing between gtd-coach and omnifocus-manager
- **Refined omnifocus-manager** — focused on OmniFocus execution (Pillars 1, 2, 4), with four-pillar framing and GTD routing (eval 82/100)
- **Rewrote gtd_guide.md** from 166 → 49 lines (concise mapping table only)
- Plugin generation workflow (CRITICAL section) unchanged

## Test plan

- [ ] Verify gtd-coach skill loads and responds to GTD methodology questions
- [ ] Verify omnifocus-manager skill still handles queries, plugin generation, and perspectives
- [ ] Verify omnifocus-agent routes GTD questions to gtd-coach and execution to omnifocus-manager
- [ ] Verify plugin generation workflow (CRITICAL section) is unmodified and functional
- [ ] Both skills pass skillsmith eval at 80+ (gtd-coach: 81, omnifocus-manager: 82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)