### PR TITLE
feat(terminal-guru): add signals-monitoring skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "terminal-guru",
       "description": "Terminal diagnostics, configuration, and zsh development expert with triage agent and two focused skills",
       "category": "development",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "author": {
         "name": "J. Greg Williams",
         "email": "283704+totallyGreg@users.noreply.github.com"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A comprehensive marketplace for Claude Code extensions, providing plugins with s
 | **marketplace-manager** | 2.5.1 | Manages Claude Code plugin marketplace operations including version syncing, skill publishing, and marketplace.json maintenance |
 | **skillsmith** | 5.2.0 | Guide for forging effective Claude skills with marketplace integration |
 | **swift-dev** | 1.2.0 | Swift development expert for SwiftUI, iOS/macOS frameworks, Server-side Swift, and Objective-C migration |
-| **terminal-guru** | 3.0.0 | Terminal diagnostics, configuration, and zsh development expert with triage agent and two focused skills |
+| **terminal-guru** | 4.0.0 | Terminal diagnostics, configuration, and zsh development expert with triage agent and two focused skills |
 
 ### Productivity (2 plugins)
 

--- a/docs/brainstorms/2026-03-05-terminal-guru-macos-logging-brainstorm.md
+++ b/docs/brainstorms/2026-03-05-terminal-guru-macos-logging-brainstorm.md
@@ -1,0 +1,319 @@
+---
+title: Signals & Monitoring skill for terminal-guru
+date: 2026-03-05
+topic: signals-monitoring terminal-guru
+status: brainstorm
+---
+
+# Signals & Monitoring Skill for terminal-guru
+
+## What We're Building
+
+A new 3rd skill in terminal-guru: **`signals-monitoring`** — covering two closely related terminal primitives:
+
+1. **Signals** — Unix process signals, `trap` in shell scripts, signal handling in zsh functions, sending/catching signals
+2. **Monitoring** — observing the system in real-time or historically: macOS unified logging, file watching, process status, and surfacing that information usefully (e.g., in a tmux pane)
+
+The two sides are naturally paired: you monitor a system to detect events, and you use signals to respond to them. macOS logging (the original trigger for this work) is one component of the monitoring side.
+
+## Skill Structure
+
+```
+plugins/terminal-guru/
+  skills/
+    terminal-emulation/    (display, terminfo, unicode)
+    zsh-dev/               (autoload, fpath, functions, testing)
+    signals-monitoring/    (NEW)
+      SKILL.md
+      references/
+        macos_logging_guide.md
+        signals_guide.md
+        file_watching_guide.md
+      scripts/             (optional: logwatch helper, diagnostic tools)
+  agents/terminal-guru.md  (updated routing)
+```
+
+---
+
+## Side 1: Signals
+
+### Unix Process Signals
+
+Core signals every terminal user encounters:
+
+| Signal | Number | Default action | Common use |
+|--------|--------|---------------|------------|
+| SIGINT | 2 | Terminate | Ctrl+C |
+| SIGTERM | 15 | Terminate | Graceful shutdown |
+| SIGKILL | 9 | Terminate (uncatchable) | Force kill |
+| SIGHUP | 1 | Terminate | Terminal closed; config reload |
+| SIGSTOP | 19 | Stop (uncatchable) | Ctrl+Z |
+| SIGCONT | 18 | Continue | Resume stopped process |
+| SIGUSR1/2 | 30/31 | Terminate | App-defined custom signals |
+
+**Sending signals:**
+```bash
+kill -TERM <pid>       # graceful shutdown
+kill -HUP <pid>        # reload config (nginx, sshd, etc.)
+kill -9 <pid>          # force kill
+pkill -f "process name"
+killall Safari
+```
+
+### `trap` in Shell Scripts
+
+`trap` intercepts signals in zsh/bash scripts — critical for cleanup and graceful shutdown:
+
+```zsh
+# Cleanup on exit (runs on EXIT pseudo-signal)
+trap 'rm -f /tmp/my-lockfile; echo "cleaned up"' EXIT
+
+# Graceful shutdown on SIGTERM
+trap 'echo "Shutting down..."; cleanup; exit 0' TERM INT
+
+# Reload config on SIGHUP (daemon pattern)
+trap 'source ~/.zshrc; echo "config reloaded"' HUP
+
+# Ignore a signal
+trap '' PIPE    # ignore SIGPIPE (broken pipe)
+
+# Reset to default
+trap - TERM
+```
+
+**Signal handling in zsh autoload functions:**
+```zsh
+# Pattern: long-running function with cleanup
+my_watcher() {
+    local tmpfile=$(mktemp)
+    trap "rm -f '$tmpfile'; return 0" INT TERM EXIT
+
+    while true; do
+        # ... do work ...
+        sleep 1
+    done
+}
+```
+
+### Signal-based Patterns
+
+- **Daemon reload**: send SIGHUP to reload config without restart
+- **Graceful shutdown**: SIGTERM → cleanup → exit (vs SIGKILL which skips cleanup)
+- **Job control**: SIGSTOP/SIGCONT for pausing/resuming background jobs
+- **Pipe handling**: SIGPIPE when writing to a closed pipe (common in shell pipelines)
+
+---
+
+## Side 2: Monitoring
+
+### macOS Unified Logging (`log` command)
+
+**Reading logs:**
+```bash
+# Historical: show logs from last hour
+sudo log show --last 1h --predicate 'subsystem=="com.apple.sharing"'
+
+# Real-time stream with predicate
+sudo log stream --predicate 's=com.apple.networking and type=error'
+
+# Collect archive for later analysis
+sudo log collect --output ~/Desktop/system.logarchive --last 20m
+
+# View archive
+sudo log show --archive ~/Desktop/system.logarchive
+
+# Stats: what processes are generating the most log volume?
+log stats --last 1h --overview
+```
+
+**Enabling debug logs for a specific subsystem** (dev workflow):
+```bash
+sudo log config --mode "level:debug" --subsystem com.mycompany.myapp
+# ... reproduce the issue ...
+sudo log config --reset --subsystem com.mycompany.myapp
+```
+
+**Writing logs from shell** (`logger`):
+```bash
+logger -t "my-script" -p user.info "task started"
+logger -t "my-script" -p user.error "something failed: $?"
+logger -t "my-script" -s "also print to stderr"
+
+# Find your messages later:
+log show --last 1h --predicate 'process=="logger" and eventMessage contains "my-script"'
+```
+
+**From zsh functions — structured logging pattern:**
+```zsh
+# Consistent logger wrapper for scripts
+_log() {
+    local level="${1:-info}"; shift
+    logger -t "${FUNCNAME[1]:-zsh}" -p "user.$level" "$*"
+}
+
+my_function() {
+    _log info "starting with args: $*"
+    # ... work ...
+    _log debug "completed successfully"
+}
+```
+
+**Predicate filtering:**
+- `subsystem=="com.apple.sharing"` — by subsystem (os_log messages only)
+- `category IN {"AirDrop", "Bonjour"}` — multiple categories
+- `process=="Safari"` — by process name
+- `type=error|fault` — by log level
+- `eventMessage contains "timeout"` — by message content
+- Shorthand: `s=com.apple.sharing and c:airdrop and type=error`
+
+### File Watching
+
+```bash
+# fswatch: run command when files change
+fswatch -o ~/project/src | xargs -n1 -I{} make build
+
+# entr: re-run tests when source changes
+ls src/**/*.swift | entr -c swift test
+
+# Watch a specific file
+fswatch ~/Library/Preferences/com.apple.dock.plist | xargs -n1 echo "Dock prefs changed:"
+```
+
+### Process Monitoring
+
+```bash
+# One-shot process snapshot
+ps aux | grep <process>
+pgrep -l Safari
+
+# Resource usage
+top -pid <pid>
+activity_monitor_data() { top -l 1 -pid "$1" }
+
+# File descriptors / open files
+lsof -p <pid>
+lsof -i :8080   # what's using port 8080?
+```
+
+---
+
+## Cross-Cutting: tmux Monitoring Panes
+
+The `logwatch` pattern — the use case the user explicitly called out:
+
+```zsh
+# zsh function: open a tmux pane with a filtered log stream
+logwatch() {
+    local subsystem="${1:-}"
+    local predicate="${2:-}"
+
+    # Build predicate from args
+    if [[ -n "$subsystem" && -z "$predicate" ]]; then
+        predicate="subsystem==\"$subsystem\""
+    fi
+
+    local cmd="sudo log stream --level debug"
+    [[ -n "$predicate" ]] && cmd+=" --predicate '$predicate'"
+
+    if [[ -n "$TMUX" ]]; then
+        tmux split-window -v "$cmd"
+    else
+        eval "$cmd"
+    fi
+}
+
+# Usage:
+logwatch com.apple.sharing
+logwatch "" "process==\"Safari\" and type=error"
+```
+
+This is an installable zsh autoload function (fits zsh-dev's generation pattern, references signals-monitoring knowledge).
+
+---
+
+## How Terminal-Guru Agent Routes
+
+Updated routing table for `agents/terminal-guru.md`:
+
+| User says... | Routes to |
+|---|---|
+| "garbled characters", "wrong colors", "box drawing broken" | terminal-emulation |
+| "create a zsh function", "slow startup", "test my config" | zsh-dev |
+| "check logs", "stream logs", "why is X doing Y", "debug my app" | **signals-monitoring** |
+| "my script isn't handling Ctrl+C", "trap SIGTERM", "kill a process gracefully" | **signals-monitoring** |
+| "watch for file changes", "run tests on save" | **signals-monitoring** |
+
+---
+
+## macOS Notification System
+
+Sending notifications from the terminal completes the signal loop: you're monitoring for events and alerting yourself when they happen.
+
+**Native AppleScript** (no dependencies):
+```bash
+# Basic notification
+osascript -e 'display notification "Build finished" with title "Terminal" subtitle "make"'
+
+# With sound
+osascript -e 'display notification "Tests passed" with title "CI" sound name "Glass"'
+```
+
+**`terminal-notifier`** (brew install terminal-notifier — richer options):
+```bash
+terminal-notifier -title "Deployment" -message "Production deploy complete" -sound default
+terminal-notifier -title "Error" -message "Build failed" -activate com.apple.Terminal
+# Click notification to bring Terminal to front; -group to replace previous notification
+terminal-notifier -title "Watch" -message "File changed: $file" -group "file-watcher"
+```
+
+**Integration pattern** — notify on completion of long-running commands:
+```zsh
+# zsh function: run command and notify when done
+notify_when_done() {
+    local cmd="$*"
+    eval "$cmd"
+    local status=$?
+    if (( status == 0 )); then
+        osascript -e "display notification \"$cmd\" with title \"Done\" sound name \"Glass\""
+    else
+        osascript -e "display notification \"$cmd (exit $status)\" with title \"Failed\" sound name \"Basso\""
+    fi
+    return $status
+}
+```
+
+Ties directly into the monitoring side: `logwatch` detects an event → triggers a notification.
+
+---
+
+## Key Decisions
+
+1. **Skill name**: `signals-monitoring` — covers both Unix signals and system monitoring.
+2. **`logwatch` function**: Lives in **both** — `signals-monitoring/scripts/` (as a skill script) AND generated as a zsh autoload function installable via `zsh-dev`'s `install_autoload.sh`.
+3. **`logger` wrapper**: Include a `_log` helper pattern in references.
+4. **`log config` (debug enabler)**: Footnote — mention it exists, don't make it a top-level section.
+5. **File watching**: Include `fswatch`/`entr` patterns in references.
+6. **Advanced tools** (`dtrace`, `dtruss`, `instruments` CLI): Skill is aware of them — note in SKILL.md as future capability, not yet covered in v1.
+7. **macOS Notification System**: Included — `osascript` display notification + `terminal-notifier`. Completes the monitor→alert loop.
+8. **iOS device logs** (`log collect --device`): Mention but don't deep-dive.
+
+## Resolved Questions
+
+- Structure: **new `signals-monitoring` skill** ✓
+- Scope: **Unix signals + macOS logging + file watching + notifications** ✓
+- `logwatch` home: **both** (signals-monitoring/scripts/ + zsh autoload function) ✓
+- `log config`: **footnote** ✓
+- dtrace/dtruss/instruments: **noted as future capability, not v1** ✓
+- macOS notifications: **in scope** (`osascript` + `terminal-notifier`) ✓
+
+## Open Questions
+
+_None — ready to plan._
+
+## Sources
+
+- `man log` (macOS 26.3) — unified log command with predicate filtering
+- `man logger` (macOS 26.3) — BSD syslog interface
+- `man kill`, `man trap` (zsh builtins)
+- Reference article: https://the-sequence.com/mac-logging-and-the-log-command-a-guide-for-apple-admins
+- Existing skills: `plugins/terminal-guru/skills/terminal-emulation/` and `zsh-dev/`

--- a/docs/plans/2026-03-05-feat-terminal-guru-macos-logging-plan.md
+++ b/docs/plans/2026-03-05-feat-terminal-guru-macos-logging-plan.md
@@ -1,0 +1,109 @@
+---
+title: "feat: Add macOS Logging to terminal-guru skill"
+type: feat
+status: active
+date: 2026-03-05
+---
+
+# feat: Add macOS Logging to terminal-guru skill
+
+Add macOS unified logging coverage to the `terminal-emulation` skill, following the established pattern of a SKILL.md section + reference file.
+
+## Problem Statement
+
+The terminal-guru plugin covers terminal display and zsh development, but lacks coverage of macOS's unified logging system. The `log` command is a critical diagnostic tool for Apple admins and developers investigating system behavior, app crashes, and macOS-specific issues — a natural fit for the skill's diagnostic scope.
+
+## Proposed Solution
+
+1. Add a "macOS System Logging" section to `terminal-emulation` SKILL.md
+2. Create `references/macos_logging_guide.md` following the pattern of `terminfo_guide.md` and `unicode_troubleshooting.md`
+3. Update the diagnostic workflow table to include macOS logging as a symptom/domain entry
+
+## Acceptance Criteria
+
+- [ ] `references/macos_logging_guide.md` created covering: unified logging overview, `log show`, `log stream`, `log collect`, predicate filtering, log levels, subsystem/category filtering
+- [ ] SKILL.md updated with a "macOS System Logging" section with common commands and when-to-use guidance
+- [ ] Diagnostic workflow table updated with macOS logging row
+- [ ] skillsmith evaluation run and score recorded
+
+## Key Content (from reference source)
+
+**Unified Logging system** (introduced WWDC 2016):
+- Replaced flat-file `/var/log/` logs; still some flat files but unified log is canonical
+- Console.app for GUI; `log` command for CLI flexibility
+
+**Core `log` subcommands:**
+```bash
+# Show recent logs
+sudo log show --last 1m
+sudo log show --last 1h --start "2026-03-05 09:00:00"
+
+# Real-time stream
+sudo log stream
+
+# Collect archive for later analysis
+sudo log collect --output ~/Desktop/SystemLogs.logarchive --last 20m
+
+# View archive
+sudo log show --archive ~/Desktop/SystemLogs.logarchive
+```
+
+**Log levels:** default, info, debug, error, fault
+```bash
+sudo log show --last 1h --level debug
+sudo log stream --level error
+```
+
+**Predicate filtering** (NSPredicate syntax):
+```bash
+# Filter by subsystem and category
+sudo log stream --debug --predicate 'subsystem=="com.apple.sharing" and category=="AirDrop"'
+
+# Filter by process name
+sudo log stream --predicate 'processImagePath contains "Safari"'
+
+# Filter by message content
+sudo log show --last 1h --predicate 'eventMessage contains "error"'
+```
+
+**Common keys for predicates:**
+- `subsystem` - reverse-DNS bundle ID namespace
+- `category` - subsystem subcategory
+- `processImagePath` - path to process binary
+- `eventMessage` - the log message text
+- `messageType` - log level (16=default, 17=info, 18=debug)
+
+## Files to Change
+
+### New: `plugins/terminal-guru/skills/terminal-emulation/references/macos_logging_guide.md`
+
+Cover:
+- What is unified logging (overview)
+- `log show` — time filtering, archive viewing
+- `log stream` — real-time monitoring
+- `log collect` — capturing archives
+- Log levels and `--level` flag
+- Predicate filtering with NSPredicate syntax
+- Common predicate keys and operators
+- Practical examples (AirDrop, specific app, error scanning)
+- Relationship to `/var/log/` flat files and Console.app
+
+### Modified: `plugins/terminal-guru/skills/terminal-emulation/SKILL.md`
+
+Add to "When to Use This Skill":
+- Investigating macOS system behavior via unified logs
+
+Add new section "4. macOS System Logging" with:
+- Brief overview linking to reference
+- Most-used commands (show, stream, collect, predicate)
+
+Update diagnostic table in Step 2:
+```
+| macOS app/system issues, crashes | macOS Logging | references/macos_logging_guide.md |
+```
+
+## Sources
+
+- Reference article: https://the-sequence.com/mac-logging-and-the-log-command-a-guide-for-apple-admins
+- Existing pattern: `plugins/terminal-guru/skills/terminal-emulation/references/terminfo_guide.md`
+- Existing SKILL.md: `plugins/terminal-guru/skills/terminal-emulation/SKILL.md`

--- a/docs/plans/2026-03-05-feat-terminal-guru-signals-monitoring-plan.md
+++ b/docs/plans/2026-03-05-feat-terminal-guru-signals-monitoring-plan.md
@@ -1,0 +1,237 @@
+---
+title: "feat: Add signals-monitoring skill to terminal-guru"
+type: feat
+status: completed
+date: 2026-03-05
+origin: docs/brainstorms/2026-03-05-terminal-guru-macos-logging-brainstorm.md
+supersedes: docs/plans/2026-03-05-feat-terminal-guru-macos-logging-plan.md
+---
+
+# feat: Add signals-monitoring skill to terminal-guru
+
+## Overview
+
+Add a new 3rd skill — `signals-monitoring` — to the terminal-guru plugin. This skill covers two closely paired terminal primitives: **Unix process signals** (sending, trapping, handling) and **system monitoring** (macOS unified logging, file watching, process inspection, and notifications). The two sides are naturally complementary: you monitor to detect events, and signals are how you respond to them.
+
+This plan supersedes the narrower `macos-logging` plan from earlier today. The scope expanded during brainstorming to capture the fuller abstraction (see brainstorm: `docs/brainstorms/2026-03-05-terminal-guru-macos-logging-brainstorm.md`).
+
+## Problem Statement
+
+terminal-guru currently covers two domains: display issues (terminal-emulation) and shell development (zsh-dev). But users regularly encounter a third class of problems:
+
+- "Why is my app doing this? Let me check the logs."
+- "My script isn't cleaning up when I Ctrl+C it."
+- "I want to watch for file changes and rebuild automatically."
+- "How do I get notified when a long deployment finishes?"
+
+These are observability and event-response problems — neither display nor shell config. Without a dedicated skill, the agent has no home to route these, and users get no structured guidance.
+
+## Proposed Solution
+
+New skill `signals-monitoring` with four domains, plus cross-cutting tmux integration:
+
+```
+plugins/terminal-guru/
+  skills/
+    terminal-emulation/          (existing — display, terminfo, unicode)
+    zsh-dev/                     (existing — autoload, fpath, functions)
+    signals-monitoring/          (NEW)
+      SKILL.md
+      references/
+        macos_logging_guide.md   (log show/stream/collect, predicates, logger)
+        signals_guide.md         (Unix signals, trap, kill, job control)
+        file_watching_guide.md   (fswatch, entr, process monitoring)
+        notifications_guide.md   (osascript, terminal-notifier)
+      scripts/
+        logwatch                 (zsh autoload function — tmux log stream pane)
+  agents/terminal-guru.md        (MODIFIED — add signals-monitoring routing)
+  .claude-plugin/plugin.json     (MODIFIED — add skill, update keywords)
+  README.md                      (MODIFIED — add skill description)
+```
+
+## Domain Coverage
+
+### Signals (`references/signals_guide.md`)
+
+Unix signals every terminal user encounters:
+
+| Signal | Number | Common use |
+|--------|--------|------------|
+| SIGINT | 2 | Ctrl+C — interrupt |
+| SIGTERM | 15 | Graceful shutdown request |
+| SIGKILL | 9 | Force kill (uncatchable) |
+| SIGHUP | 1 | Terminal closed; reload config |
+| SIGSTOP/CONT | 19/18 | Pause/resume (Ctrl+Z, `fg`) |
+| SIGUSR1/2 | 30/31 | App-defined custom signals |
+| SIGPIPE | 13 | Broken pipe in shell pipelines |
+
+Key patterns to document:
+- Sending: `kill -TERM <pid>`, `pkill -f name`, `killall App`
+- `trap` for cleanup on EXIT, INT, TERM, HUP in scripts
+- Long-running zsh function pattern with cleanup trap
+- Daemon reload via SIGHUP (`kill -HUP $(pgrep nginx)`)
+- SIGPIPE suppression in shell pipelines
+
+### macOS Unified Logging (`references/macos_logging_guide.md`)
+
+Reading logs (see brainstorm for full command map):
+- `log show` — historical logs with `--last`, `--predicate`, `--style`
+- `log stream` — real-time with `--predicate`, `--level`, `--timeout`
+- `log collect` — snapshot to `.logarchive`, including paired iOS devices
+- `log stats` — per-process/sender log volume analysis
+
+Writing logs from shell:
+- `logger -t <tag> -p user.info "message"` — writes into unified log
+- `_log` helper wrapper for consistent tagging in zsh functions
+- Retrieving: `log show --predicate 'process=="logger" and eventMessage contains "my-tag"'`
+
+Predicate filtering (NSPredicate + shorthand):
+- Keys: `subsystem`, `category`, `process`, `eventMessage`, `messageType`, `sender`
+- Shorthand: `s=com.apple.sharing and c:airdrop and type=error`
+- Compound: `(subsystem=="com.example") && (category IN {"net","auth"})`
+
+> **Footnote — `log config`**: Enabling debug logging for a specific subsystem (`sudo log config --mode "level:debug" --subsystem com.myapp`) is useful during development but requires root and affects system-wide logging. Mentioned in references, not a top-level capability.
+
+> **Future capability — `dtrace`/`dtruss`/`instruments` CLI**: The skill is aware these tools exist for deep system tracing. Not covered in v1 — noted in SKILL.md under "Advanced / Future" for discovery.
+
+### File Watching (`references/file_watching_guide.md`)
+
+- `fswatch -o <path> | xargs -n1 <cmd>` — run command on any change
+- `ls src/**/*.swift | entr -c swift test` — re-run tests on source changes
+- `pgrep`, `lsof -p <pid>`, `lsof -i :8080` — process inspection
+- `top -pid <pid>` — per-process resource usage
+
+### Notifications (`references/notifications_guide.md`)
+
+Completes the monitor→alert loop (see brainstorm: decision #7).
+
+Native (no dependencies):
+```bash
+osascript -e 'display notification "Build done" with title "Terminal" sound name "Glass"'
+```
+
+`terminal-notifier` (richer — `brew install terminal-notifier`):
+```bash
+terminal-notifier -title "Deploy" -message "Production live" -sound default
+terminal-notifier -title "Watch" -message "File: $file" -group "file-watcher"
+```
+
+`notify_when_done` zsh function pattern — wraps any command, notifies on success/failure.
+
+### Cross-Cutting: `logwatch` tmux Integration
+
+The key integration pattern: open a tmux pane with a filtered `log stream` for live monitoring while working (see brainstorm: decision #2).
+
+```zsh
+# scripts/logwatch — installable zsh autoload function
+logwatch() {
+    local subsystem="${1:-}"
+    local predicate="${2:-}"
+    [[ -n "$subsystem" && -z "$predicate" ]] && predicate="subsystem==\"$subsystem\""
+    local cmd="sudo log stream --level debug"
+    [[ -n "$predicate" ]] && cmd+=" --predicate '$predicate'"
+    if [[ -n "$TMUX" ]]; then
+        tmux split-window -v "$cmd"
+    else
+        eval "$cmd"
+    fi
+}
+```
+
+Lives in **both** (see brainstorm: decision #2):
+1. `signals-monitoring/scripts/logwatch` — documented in SKILL.md as a provided script
+2. Installable as a zsh autoload function via `zsh-dev`'s `install_autoload.sh`
+
+## Technical Considerations
+
+**Agent routing update** — `agents/terminal-guru.md` needs new rows in the routing table:
+
+| Symptom | Routes to |
+|---|---|
+| "check logs", "stream logs", "why is X doing Y" | signals-monitoring |
+| "Ctrl+C not working", "trap SIGTERM", "graceful shutdown" | signals-monitoring |
+| "watch files", "run on change", "trigger on save" | signals-monitoring |
+| "notify me when done", "send a notification" | signals-monitoring |
+| "kill a process", "send a signal" | signals-monitoring |
+
+**Plugin.json** — update `keywords` to include `logging`, `signals`, `monitoring`, `notifications`, and update `description`.
+
+**README.md** — add `signals-monitoring` component block following the existing pattern.
+
+**zsh-dev cross-reference** — add a short "Logging from Zsh Functions" note to `references/zsh_function_patterns.md` pointing to signals-monitoring for `logger`/`_log` patterns.
+
+**Skillsmith evaluation** — run after implementation, record score in IMPROVEMENT_PLAN.md.
+
+## Implementation Phases
+
+### Phase 1: Skill Scaffold + macOS Logging
+
+*Core capability — the original trigger for this work.*
+
+- [x] Create `skills/signals-monitoring/` directory structure
+- [x] Write `SKILL.md` — overview, when-to-use, all 4 domains, `logwatch` usage, dtrace future note
+- [x] Write `references/macos_logging_guide.md` — `log show/stream/collect/stats`, predicate reference (NSPredicate + shorthand), `logger` usage, `_log` helper pattern
+- [x] Add `log config` footnote in logging guide
+- [x] Update `plugin.json` keywords and description
+
+### Phase 2: Signals Reference
+
+- [x] Write `references/signals_guide.md` — signal table, `kill`/`pkill`/`killall`, `trap` patterns (EXIT cleanup, TERM/INT handler, HUP reload, PIPE suppress), long-running zsh function template with trap
+- [x] Update agent routing table in `agents/terminal-guru.md`
+
+### Phase 3: File Watching + Notifications
+
+- [x] Write `references/file_watching_guide.md` — `fswatch`, `entr`, `pgrep`, `lsof` patterns
+- [x] Write `references/notifications_guide.md` — `osascript` display notification, `terminal-notifier` (with `-group`, `-activate`), `notify_when_done` function pattern
+- [x] Update `README.md` with signals-monitoring component block
+
+### Phase 4: `logwatch` Function + Integration
+
+- [x] Write `scripts/logwatch` as a complete zsh autoload function with subsystem and raw predicate modes, tmux-aware fallback
+- [x] Add note to `zsh-dev/references/zsh_function_patterns.md` cross-referencing signals-monitoring for logging patterns
+- [x] Run skillsmith evaluation: `uv run plugins/skillsmith/skills/skillsmith/scripts/evaluate_skill.py plugins/terminal-guru/skills/signals-monitoring`
+- [x] Record eval score in `skills/signals-monitoring/IMPROVEMENT_PLAN.md` (create it)
+
+## Acceptance Criteria
+
+- [ ] `skills/signals-monitoring/SKILL.md` created and covers all 4 domains with clear when-to-use trigger phrases
+- [ ] `references/macos_logging_guide.md` covers: `log show/stream/collect/stats`, predicate filtering (NSPredicate + shorthand keys), `logger` usage, `_log` helper, `log config` footnote
+- [ ] `references/signals_guide.md` covers: signal table, sending signals, `trap` patterns (EXIT, TERM, INT, HUP, PIPE), long-running function template
+- [ ] `references/file_watching_guide.md` covers: `fswatch`, `entr`, `pgrep`, `lsof`
+- [ ] `references/notifications_guide.md` covers: `osascript` notification, `terminal-notifier`, `notify_when_done` pattern
+- [ ] `scripts/logwatch` is a working zsh autoload function, tmux-aware, installable via `install_autoload.sh`
+- [ ] `agents/terminal-guru.md` updated with signals-monitoring routing rows
+- [ ] `plugin.json` updated with new keywords and description
+- [ ] `README.md` updated with signals-monitoring component
+- [ ] `zsh-dev` references cross-link to signals-monitoring for logger patterns
+- [ ] dtrace/dtruss noted as future capability in SKILL.md
+- [ ] Skillsmith eval run and score recorded in IMPROVEMENT_PLAN.md
+
+## Dependencies & Risks
+
+- **`terminal-notifier`** is a Homebrew package — not pre-installed. Document as optional; always cover native `osascript` fallback first.
+- **`fswatch`/`entr`** are also Homebrew packages — same pattern: document as installable, show native alternatives where possible.
+- **`log` commands often require `sudo`** — note this consistently in examples. Non-root `log show` only shows process-owned logs.
+- **Agent routing** — adding signals-monitoring requires careful ordering so it doesn't accidentally swallow zsh-dev or terminal-emulation queries. Review the routing table holistically before committing.
+
+## Sources & References
+
+### Origin
+
+- **Brainstorm document:** [docs/brainstorms/2026-03-05-terminal-guru-macos-logging-brainstorm.md](docs/brainstorms/2026-03-05-terminal-guru-macos-logging-brainstorm.md)
+  Key decisions carried forward: new `signals-monitoring` skill (not split), `logwatch` in both scripts/ and as zsh autoload, macOS notifications in scope, dtrace as future capability
+
+### Internal References
+
+- Existing skill pattern: `plugins/terminal-guru/skills/terminal-emulation/SKILL.md`
+- Existing reference pattern: `plugins/terminal-guru/skills/terminal-emulation/references/terminfo_guide.md`
+- Agent routing structure: `plugins/terminal-guru/agents/terminal-guru.md:53`
+- Install helper: `plugins/terminal-guru/skills/zsh-dev/scripts/install_autoload.sh`
+- Function patterns to cross-reference: `plugins/terminal-guru/skills/zsh-dev/references/zsh_function_patterns.md`
+
+### External References
+
+- macOS log command guide: https://the-sequence.com/mac-logging-and-the-log-command-a-guide-for-apple-admins
+- `man log` (macOS 26.3) — predicate filtering, all subcommands
+- `man logger` (macOS 26.3) — BSD syslog interface
+- Apple Predicate Programming Guide: https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/Predicates/Articles/pSyntax.html

--- a/plugins/terminal-guru/.claude-plugin/plugin.json
+++ b/plugins/terminal-guru/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "terminal-guru",
-  "version": "3.0.0",
-  "description": "Terminal diagnostics, configuration, and zsh development expert for Unix systems. Includes an orchestrator agent for diagnostic triage and two focused skills: terminal-emulation (terminfo, Unicode, display) and zsh-dev (autoload functions, fpath, testing, performance).",
+  "version": "4.0.0",
+  "description": "Terminal diagnostics, configuration, zsh development, and system observability expert for macOS/Unix systems. Includes an orchestrator agent for diagnostic triage and three focused skills: terminal-emulation (terminfo, Unicode, display), zsh-dev (autoload functions, fpath, testing, performance), and signals-monitoring (macOS logging, Unix signals, file watching, notifications).",
   "author": {
     "name": "J. Greg Williams",
     "email": "283704+totallyGreg@users.noreply.github.com"
@@ -13,6 +13,11 @@
     "unicode",
     "zsh",
     "shell",
-    "diagnostics"
+    "diagnostics",
+    "logging",
+    "signals",
+    "monitoring",
+    "notifications",
+    "macos"
   ]
 }

--- a/plugins/terminal-guru/README.md
+++ b/plugins/terminal-guru/README.md
@@ -26,10 +26,22 @@ Zsh shell development and testing (~55% of content):
 - Performance profiling and optimization
 - Plugin compatibility validation
 
+### Skill: signals-monitoring
+System observability and event-response:
+- macOS unified logging (log show/stream/collect, predicate filtering)
+- Writing structured log entries from shell scripts (logger, _log pattern)
+- Unix process signals (kill, pkill, trap patterns)
+- Graceful shutdown and cleanup handlers for zsh scripts
+- File watching (fswatch, entr)
+- Process inspection (pgrep, lsof, ps)
+- macOS notifications (osascript, terminal-notifier)
+- `logwatch` — tmux pane with filtered live log stream
+
 ## Version History
 
 | Version | Changes |
 |---------|---------|
+| 4.0.0 | Added signals-monitoring skill: unified logging, signals/trap, file watching, notifications |
 | 3.0.0 | Split monolithic skill into plugin with agent + two focused skills |
 | 2.1.0 | Added zsh function patterns, completion guide, Plugin Standard references |
 | 2.0.0 | Initial release with terminal diagnostics and zsh configuration |

--- a/plugins/terminal-guru/agents/terminal-guru.md
+++ b/plugins/terminal-guru/agents/terminal-guru.md
@@ -1,7 +1,7 @@
 ---
 name: terminal-guru
 description: |
-  Use this agent when the user has ambiguous terminal or shell problems that span multiple domains, needs diagnostic triage to identify root causes, or has cross-domain issues involving both terminal display and shell configuration. This agent routes to the correct skill (terminal-emulation or zsh-dev) after initial triage. Examples:
+  Use this agent when the user has ambiguous terminal or shell problems that span multiple domains, needs diagnostic triage to identify root causes, or has cross-domain issues involving terminal display, shell configuration, system logging, or process signals. This agent routes to the correct skill (terminal-emulation, zsh-dev, or signals-monitoring) after initial triage. Examples:
 
   <example>
   Context: User reports garbled characters in terminal
@@ -46,9 +46,10 @@ tools: ["Read", "Bash", "Grep", "Glob"]
 
 You are a diagnostic triage and routing agent for terminal and shell issues. Your role is to identify the problem domain, run initial diagnostics, and route to the appropriate skill for resolution.
 
-**Your Two Skills:**
+**Your Three Skills:**
 - **terminal-emulation**: Terminfo, Unicode/UTF-8, locale, display issues, SSH terminal, TUI apps
 - **zsh-dev**: Zsh configuration, autoload functions, fpath, completions, testing framework, performance
+- **signals-monitoring**: macOS system logs, Unix process signals, trap/cleanup, file watching, notifications
 
 ## Symptom-to-Domain Routing
 
@@ -64,6 +65,13 @@ You are a diagnostic triage and routing agent for terminal and shell issues. You
 | SSH + display issues | terminal-emulation | zsh-dev |
 | SSH + functions not loading | zsh-dev | terminal-emulation |
 | Config changes broke everything | zsh-dev | terminal-emulation |
+| Check logs, stream logs, debug app behavior | signals-monitoring | - |
+| Ctrl+C not working, script not cleaning up | signals-monitoring | zsh-dev |
+| trap SIGTERM, graceful shutdown | signals-monitoring | - |
+| Kill a process, send a signal, reload config | signals-monitoring | - |
+| Watch files, run on change, trigger on save | signals-monitoring | - |
+| Notify when done, send a notification | signals-monitoring | - |
+| Log from a shell script, instrument a function | signals-monitoring | zsh-dev |
 
 ## Diagnostic Process
 
@@ -71,8 +79,9 @@ You are a diagnostic triage and routing agent for terminal and shell issues. You
 2. **Run initial diagnostics** if the domain is unclear:
    - Check `echo $TERM` and `locale` for display issues
    - Check `print -l $fpath` and `whence -v <func>` for shell issues
+   - Check `sudo log show --last 5m` for recent system events
 3. **Route to the correct skill** by reading the appropriate SKILL.md and references
-4. **Handle cross-domain issues** by addressing each domain in sequence (typically terminal-emulation first, then zsh-dev)
+4. **Handle cross-domain issues** by addressing each domain in sequence (typically terminal-emulation first, then zsh-dev; signals-monitoring is usually standalone)
 
 ## Function Generation Routing
 

--- a/plugins/terminal-guru/skills/signals-monitoring/IMPROVEMENT_PLAN.md
+++ b/plugins/terminal-guru/skills/signals-monitoring/IMPROVEMENT_PLAN.md
@@ -1,0 +1,19 @@
+# signals-monitoring Improvement Plan
+
+## Active Issues
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#86](https://github.com/totallyGreg/claude-mp/issues/86) | feat: Add signals-monitoring skill to terminal-guru | completed |
+
+## Version History
+
+| Version | Score | Changes | Issue |
+|---------|-------|---------|-------|
+| 1.0.0 | 88/100 | Initial release: macOS logging, Unix signals, file watching, notifications, logwatch tmux function | #86 |
+
+## Future Capabilities (noted, not yet covered)
+
+- `dtrace` / `dtruss` — DTrace-based system call tracing
+- `instruments` CLI (`xcrun xctrace`) — Apple profiling and tracing
+- `ktrace` / `kdebug` — kernel-level event tracing

--- a/plugins/terminal-guru/skills/signals-monitoring/SKILL.md
+++ b/plugins/terminal-guru/skills/signals-monitoring/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: signals-monitoring
+description: This skill should be used when working with Unix process signals, shell trap handlers, macOS unified logging, file watching, process monitoring, and terminal notifications. Use when users ask to "check system logs", "debug my app", "fix script cleanup on Ctrl+C", "add signal handling to a script", "configure log streaming", "build a file watcher", "send a notification from the terminal", or "open a log stream in tmux".
+metadata:
+  version: "1.0.0"
+---
+
+# Signals & Monitoring
+
+## Overview
+
+Two closely paired terminal primitives: **signals** (sending and handling Unix process signals in shell scripts) and **monitoring** (observing system state via macOS unified logging, file watching, and process inspection). Completes the loop with **notifications** — alert yourself when something happens.
+
+## When to Use This Skill
+
+- Checking macOS system logs (`log show`, `log stream`)
+- Diagnosing why an app is misbehaving or crashing
+- Real-time log streaming in a tmux pane (`logwatch`)
+- Writing structured log entries from shell scripts (`logger`)
+- Handling Ctrl+C, SIGTERM, SIGHUP in zsh scripts with `trap`
+- Graceful shutdown patterns for long-running shell functions
+- Sending a signal to reload a process config (SIGHUP)
+- Watching files for changes and triggering actions (`fswatch`, `entr`)
+- Inspecting process resource usage or open file descriptors
+- Sending macOS notifications from the terminal (`osascript`, `terminal-notifier`)
+- Notifying yourself when a long command finishes
+
+## Core Capabilities
+
+### 1. macOS System Logging
+
+Read, stream, and write to macOS's unified logging system. See `references/macos_logging_guide.md` for the full reference.
+
+**Common operations:**
+
+```bash
+# Show logs from last hour, filtered to a subsystem
+sudo log show --last 1h --predicate 'subsystem=="com.apple.sharing"'
+
+# Real-time stream — errors from a process
+sudo log stream --predicate 'process=="Safari" and type=error'
+
+# Stream filtered by subsystem in shorthand
+sudo log stream --predicate 's=com.apple.networking and type=error|fault'
+
+# Write a log entry from a script
+logger -t "my-script" -p user.info "task started"
+
+# Find your entries later
+log show --last 1h --predicate 'process=="logger" and eventMessage contains "my-script"'
+```
+
+**When to use**: Diagnosing macOS app or system behavior, instrumenting shell scripts, post-mortem investigation of crashes or unexpected behavior.
+
+### 2. Unix Signals
+
+Send, catch, and handle process signals in shell scripts. See `references/signals_guide.md` for the full reference.
+
+**Common operations:**
+
+```bash
+# Graceful shutdown
+kill -TERM <pid>
+
+# Reload config (nginx, sshd, launchd services)
+kill -HUP $(pgrep nginx)
+
+# Force kill (uncatchable)
+kill -9 <pid>
+pkill -f "process name pattern"
+```
+
+**`trap` for script cleanup:**
+
+```zsh
+# Cleanup temp files on any exit
+trap 'rm -f /tmp/my-lockfile' EXIT
+
+# Graceful shutdown handler
+trap 'echo "interrupted, cleaning up..."; cleanup_fn; exit 1' INT TERM
+
+# Reload config on HUP
+trap 'source ~/.zshrc' HUP
+```
+
+**When to use**: Scripts that create temp files, hold locks, or run background processes — always add an EXIT trap. Long-running functions that should handle Ctrl+C gracefully.
+
+### 3. File Watching
+
+Run commands automatically when files change. See `references/file_watching_guide.md` for the full reference.
+
+```bash
+# Run make when any source file changes (requires: brew install fswatch)
+fswatch -o ./src | xargs -n1 -I{} make build
+
+# Re-run tests on source changes (requires: brew install entr)
+ls src/**/*.swift | entr -c swift test
+
+# Watch and notify on change
+fswatch ~/important-file | xargs -n1 -I{} terminal-notifier -message "File changed"
+```
+
+**When to use**: Development workflows where you want automatic rebuild/test on save, or monitoring a config file for changes.
+
+### 4. Notifications
+
+Send macOS notifications from the terminal. See `references/notifications_guide.md` for the full reference.
+
+```bash
+# Native — no dependencies
+osascript -e 'display notification "Build done" with title "Terminal" sound name "Glass"'
+
+# terminal-notifier — richer options (brew install terminal-notifier)
+terminal-notifier -title "Deploy" -message "Production live" -sound default
+```
+
+**`notify_when_done` pattern** — wrap any command and alert on completion:
+
+```zsh
+notify_when_done() {
+    "$@"
+    local status=$?
+    if (( status == 0 )); then
+        osascript -e "display notification \"$*\" with title \"Done ✓\" sound name \"Glass\""
+    else
+        osascript -e "display notification \"$* (exit $status)\" with title \"Failed ✗\" sound name \"Basso\""
+    fi
+    return $status
+}
+
+# Usage: notify_when_done make build
+# Usage: notify_when_done kubectl apply -f deployment.yaml
+```
+
+**When to use**: Long-running commands (builds, deploys, test suites) where you want to be alerted when done so you can context-switch away.
+
+## `logwatch` — tmux Log Stream Pane
+
+Open a tmux split pane with a filtered real-time log stream. Useful while developing: keep a log stream open alongside your editor or test runner.
+
+```bash
+# Install the autoload function
+bash /path/to/zsh-dev/scripts/install_autoload.sh logwatch
+
+# Usage after install:
+logwatch com.apple.sharing              # stream by subsystem
+logwatch "" "process==\"Safari\""       # stream by raw predicate
+logwatch                                # stream all (unfiltered)
+```
+
+The script is at `scripts/logwatch`. When inside tmux, it opens a new split pane; otherwise streams in the current terminal.
+
+## Diagnostic Workflow
+
+| Symptom | Domain | Reference |
+|---------|--------|-----------|
+| App misbehaving, crash investigation | macOS Logging | `references/macos_logging_guide.md` |
+| Script not handling Ctrl+C, leaving temp files | Signals / trap | `references/signals_guide.md` |
+| Want to rebuild/test automatically on file save | File Watching | `references/file_watching_guide.md` |
+| Alert when long command finishes | Notifications | `references/notifications_guide.md` |
+| Need to kill or pause a process | Signals | `references/signals_guide.md` |
+
+## Common Use Cases
+
+### "Why is [app] doing this?"
+1. Stream its logs: `sudo log stream --predicate 'process=="AppName"' --level debug`
+2. Narrow with predicate: add `and type=error` to focus on errors
+3. Check recent history: `sudo log show --last 30m --predicate 'process=="AppName"'`
+4. Refer to `references/macos_logging_guide.md` for predicate syntax
+
+### "My script leaves temp files when I Ctrl+C"
+1. Add `trap 'rm -f "$tmpfile"' EXIT` at the top of your script
+2. EXIT fires on Ctrl+C (SIGINT), SIGTERM, and normal exit
+3. Refer to `references/signals_guide.md` for trap patterns
+
+### "I want tests to run automatically when I save"
+1. `brew install entr`
+2. `ls src/**/*.swift | entr -c swift test`
+3. Or with fswatch: `fswatch -o ./src | xargs -n1 -I{} make test`
+4. Refer to `references/file_watching_guide.md`
+
+### "Notify me when my deploy finishes"
+1. Use `notify_when_done kubectl apply -f k8s/`
+2. Or append: `make deploy && osascript -e 'display notification "Deploy done" with title "CI"'`
+3. Refer to `references/notifications_guide.md`
+
+## Resources
+
+### scripts/
+- **`logwatch`** — zsh autoload function: open tmux pane with filtered `log stream`
+
+### references/
+- **`macos_logging_guide.md`** — macOS unified log command, predicate filtering, writing logs from shell
+- **`signals_guide.md`** — Unix signal table, kill/pkill, trap patterns for shell scripts
+- **`file_watching_guide.md`** — fswatch, entr, process inspection (pgrep, lsof)
+- **`notifications_guide.md`** — osascript notifications, terminal-notifier, notify_when_done pattern
+
+## Advanced / Future Capabilities
+
+The following tools exist for deep system tracing and are known to this skill, but **not yet covered in v1 guidance**. Ask about them and expect a pointer to documentation rather than step-by-step help:
+
+- **`dtrace`** / **`dtruss`** — DTrace-based system call tracing (requires SIP disabled on modern macOS)
+- **`instruments` CLI** — Apple's profiling and tracing tool (`xcrun xctrace`)
+- **`ktrace`** / **`kdebug`** — kernel-level event tracing

--- a/plugins/terminal-guru/skills/signals-monitoring/references/file_watching_guide.md
+++ b/plugins/terminal-guru/skills/signals-monitoring/references/file_watching_guide.md
@@ -1,0 +1,283 @@
+# File Watching Guide
+
+## Overview
+
+File watching triggers actions automatically when files or directories change — useful for rebuilding on save, running tests continuously, syncing files, or monitoring config changes. macOS has built-in FSEvents support; the best CLI tools wrap it.
+
+---
+
+## `fswatch` — Event-Based File Watcher
+
+Monitors paths using macOS FSEvents (or kqueue/inotify on other platforms). Events are printed to stdout; pipe to a command to act on them.
+
+**Install:** `brew install fswatch`
+
+### Basic Usage
+
+```bash
+# Watch a directory — print a line for each changed file
+fswatch ./src
+
+# Watch and run a command on any change (-o collapses events into a count)
+fswatch -o ./src | xargs -n1 -I{} make build
+
+# Watch specific file types
+fswatch -e ".*" -i "\.swift$" ./src | xargs -n1 -I{} swift build
+
+# Watch multiple paths
+fswatch ./src ./config | xargs -n1 echo "Changed:"
+
+# Watch and run tests
+fswatch -o ./src | xargs -n1 -I{} sh -c 'clear && swift test'
+```
+
+### Useful Flags
+
+| Flag | Description |
+|------|-------------|
+| `-o` | Collapse events; print count (use with xargs -n1) |
+| `-r` | Recursive (default for directories) |
+| `-l <secs>` | Latency between events (default 1s) |
+| `-e <regex>` | Exclude paths matching pattern |
+| `-i <regex>` | Include only paths matching pattern |
+| `--event Created` | Filter by event type (Created, Updated, Removed, Renamed) |
+| `-1` | Exit after first event |
+
+```bash
+# Rebuild only when .go files change, excluding vendor/
+fswatch -o -e "vendor" -i "\.go$" . | xargs -n1 -I{} go build ./...
+
+# Watch a config file and reload a service
+fswatch -1 /etc/nginx/nginx.conf && sudo nginx -s reload
+
+# Print full event info (file + event type)
+fswatch --event-flags ./src
+```
+
+### Notification on Change
+
+```bash
+# Notify when a file changes
+fswatch ~/Documents/important.txt | \
+    xargs -n1 -I{} osascript -e 'display notification "File changed" with title "fswatch"'
+```
+
+---
+
+## `entr` — Run Commands on File Change
+
+More ergonomic than fswatch for development loops. Reads a list of files from stdin, re-runs a command when any changes.
+
+**Install:** `brew install entr`
+
+### Basic Usage
+
+```bash
+# Re-run tests when any Swift file changes
+ls src/**/*.swift | entr -c swift test
+
+# Rebuild when any Go file changes
+find . -name "*.go" | entr -c go build ./...
+
+# Reload server when config changes
+echo config.yaml | entr -r ./myserver --config config.yaml
+
+# Run shell command
+ls *.md | entr -c sh -c 'pandoc index.md -o index.html && echo "Built"'
+```
+
+### Useful Flags
+
+| Flag | Description |
+|------|-------------|
+| `-c` | Clear screen before each run |
+| `-r` | Restart a long-running process (send SIGTERM, wait, restart) |
+| `-s` | Use `sh -c` to run the command (enables shell features) |
+| `-p` | Postpone first run until a file changes |
+| `-d` | Track new files added to watched directories |
+
+```bash
+# Restart a dev server when source changes (with -r for long-running processes)
+find . -name "*.py" | entr -r python server.py
+
+# Watch for new files too
+ls src/*.js | entr -d -c npm test
+
+# Postpone first execution
+find . -name "*.rb" | entr -p ruby test.rb
+```
+
+### Combining with find
+
+```bash
+# Recursive with find (more flexible than ls glob)
+find src -name "*.swift" | entr -c swift test
+
+# Multiple file types
+find . \( -name "*.go" -o -name "*.tmpl" \) | entr -c go build
+```
+
+---
+
+## Process Inspection
+
+### `pgrep` / `pkill` — Find Processes
+
+```bash
+# Find PIDs by name
+pgrep Safari              # PIDs only
+pgrep -l Safari           # PIDs + names
+pgrep -f "python script"  # match full command line
+
+# Find and display process info
+pgrep -a nginx            # full command line
+
+# Count matching processes
+pgrep -c nginx
+```
+
+### `ps` — Process Snapshot
+
+```bash
+# All processes, full detail
+ps aux
+
+# Find a specific process
+ps aux | grep -i safari
+
+# Tree view (process hierarchy)
+ps auxf
+
+# Specific fields for a PID
+ps -o pid,ppid,pcpu,pmem,comm -p <pid>
+
+# All processes by a user
+ps -u $(whoami) aux
+```
+
+### `lsof` — List Open Files and Network Connections
+
+`lsof` ("list open files") shows everything a process has open — files, sockets, pipes.
+
+```bash
+# All open files for a process
+lsof -p <pid>
+
+# What process is using a port
+lsof -i :8080
+lsof -i :443
+lsof -i TCP:3000
+
+# All network connections
+lsof -i
+
+# Files a specific process has open (by name)
+lsof -c Safari
+
+# Who has a file open
+lsof /path/to/file
+
+# Files in a directory
+lsof +D /path/to/dir
+
+# Filter to just network sockets
+lsof -i -n -P   # -n = no hostname lookup, -P = no port name lookup
+```
+
+### `top` / `htop` — Resource Usage
+
+```bash
+# Interactive top (press 'q' to quit)
+top
+
+# Non-interactive snapshot — one iteration
+top -l 1
+
+# Monitor a specific PID
+top -pid <pid>
+
+# Sort by CPU usage
+top -o cpu
+
+# Sort by memory
+top -o mem
+
+# htop — better UI (brew install htop)
+htop
+htop --pid <pid>
+```
+
+### `vm_stat` / `iostat` — System Resources
+
+```bash
+# Memory statistics
+vm_stat
+
+# Disk I/O statistics (1-second interval)
+iostat -d 1
+
+# Network interface statistics
+netstat -i
+```
+
+---
+
+## Native File Watch (No Dependencies)
+
+For simple cases without installing fswatch/entr:
+
+```bash
+# Poll a file for changes with a loop
+watch_file() {
+    local file="$1"
+    local cmd="${@:2}"
+    local prev_hash=""
+    while true; do
+        local curr_hash
+        curr_hash=$(md5 -q "$file" 2>/dev/null)
+        if [[ "$curr_hash" != "$prev_hash" ]]; then
+            prev_hash="$curr_hash"
+            eval "$cmd"
+        fi
+        sleep 1
+    done
+}
+
+# Usage: watch_file config.yaml "echo 'config changed'"
+```
+
+> This polling approach has ~1s latency and is CPU-intensive for many files. Prefer `fswatch` or `entr` for real use.
+
+---
+
+## Practical Workflows
+
+### Auto-test on save (Swift)
+```bash
+find . -name "*.swift" | entr -c swift test 2>&1 | head -50
+```
+
+### Auto-rebuild and notify (any project)
+```bash
+fswatch -o ./src | xargs -n1 -I{} sh -c \
+    'make build 2>&1 && \
+     osascript -e "display notification \"Build OK\" with title \"Make\" sound name \"Glass\"" || \
+     osascript -e "display notification \"Build FAILED\" with title \"Make\" sound name \"Basso\""'
+```
+
+### Watch a log file (flat file, not unified log)
+```bash
+tail -f /var/log/install.log
+tail -f /var/log/system.log | grep -i error
+```
+
+### Monitor when a process finishes
+```bash
+# Wait for a PID to exit, then notify
+wait_for_pid() {
+    local pid=$1
+    while kill -0 "$pid" 2>/dev/null; do sleep 1; done
+    osascript -e "display notification \"Process $pid finished\" with title \"Done\""
+}
+wait_for_pid 12345
+```

--- a/plugins/terminal-guru/skills/signals-monitoring/references/macos_logging_guide.md
+++ b/plugins/terminal-guru/skills/signals-monitoring/references/macos_logging_guide.md
@@ -1,0 +1,308 @@
+# macOS Unified Logging Guide
+
+## Overview
+
+Apple's unified logging system (introduced WWDC 2016) is the canonical way to read what macOS and macOS apps are doing. It replaced fragmented flat files in `/var/log/` with a single, structured, high-performance store accessible via the `log` command and Console.app.
+
+Key properties:
+- Covers all Apple platforms (macOS, iOS via `log collect --device`)
+- Logs are structured with subsystem, category, process, and level metadata
+- Default and info levels are stored in memory and may roll off; debug/fault are always persisted
+- Most `log show` and `log stream` operations require `sudo` for full system access
+
+The `log` binary lives at `/usr/bin/log`. Run `man log` for full reference.
+
+---
+
+## Reading Logs
+
+### `log show` — Historical Log Retrieval
+
+Show logs stored in the system datastore or a `.logarchive` file.
+
+```bash
+# Last minute of default-level logs
+sudo log show --last 1m
+
+# Last hour including info messages
+sudo log show --last 1h --info
+
+# Last hour including info + debug messages
+sudo log show --last 1h --info --debug
+
+# Specific time range
+sudo log show --start "2026-03-05 09:00:00" --end "2026-03-05 09:30:00"
+
+# From last boot
+sudo log show --last boot
+```
+
+**Output styles** (`--style`):
+- `default` — human readable with full metadata (ISO-8601, thread, PID, subsystem, category)
+- `compact` — same info, less horizontal space
+- `json` — machine-parseable JSON array
+- `ndjson` — newline-delimited JSON (one event per line, good for streaming/piping)
+- `syslog` — legacy syslog format
+
+```bash
+# Machine-readable output
+sudo log show --last 1h --style ndjson | jq 'select(.messageType=="error")'
+```
+
+**Filtering by process:**
+```bash
+sudo log show --last 1h --process Safari
+sudo log show --last 1h --process 1234       # by PID
+```
+
+**View a collected archive:**
+```bash
+sudo log show --archive ~/Desktop/system.logarchive
+sudo log show --archive ~/Desktop/system.logarchive --predicate 'type=error'
+```
+
+---
+
+### `log stream` — Real-Time Monitoring
+
+Stream log events as they happen. Press Ctrl+C to stop.
+
+```bash
+# All default-level events (very noisy)
+sudo log stream
+
+# Only error and fault level
+sudo log stream --level default   # default only
+sudo log stream --level info      # default + info
+sudo log stream --level debug     # all levels
+
+# Auto-stop after 5 minutes
+sudo log stream --timeout 5m
+
+# Compact format for easier reading
+sudo log stream --style compact --predicate 'process=="Finder"'
+```
+
+---
+
+### `log collect` — Snapshot to Archive
+
+Collect logs into a `.logarchive` bundle for offline analysis or sharing.
+
+```bash
+# Last 20 minutes to desktop
+sudo log collect --output ~/Desktop/system.logarchive --last 20m
+
+# Specific time range
+sudo log collect --output ~/Desktop/incident.logarchive \
+    --start "2026-03-05 14:00:00" --end "2026-03-05 14:30:00"
+
+# Paired iOS/iPadOS device (first found)
+sudo log collect --device --output ~/Desktop/device.logarchive --last 1h
+
+# Named device
+sudo log collect --device-name "My iPhone" --output ~/Desktop/device.logarchive --last 30m
+```
+
+Then view with:
+```bash
+sudo log show --archive ~/Desktop/system.logarchive
+sudo log show --archive ~/Desktop/system.logarchive --predicate 'type=error' --last 30m
+```
+
+> Note: `sysdiagnose` (filed feedback to Apple) automatically includes a `system_logs.logarchive`.
+
+---
+
+### `log stats` — Log Volume Analysis
+
+Understand which processes or senders generate the most log traffic.
+
+```bash
+# Overview of last hour
+log stats --last 1h --overview
+
+# Per-process breakdown, sorted by event count
+log stats --last 1h --per-process --sort events
+
+# Per-sender (library/framework) breakdown
+log stats --last 1h --per-sender --sort bytes
+
+# Stats for an archive
+log stats --archive ~/Desktop/system.logarchive --overview
+```
+
+Useful for identifying noisy processes before narrowing with predicates.
+
+---
+
+## Predicate Filtering
+
+Predicates are the most powerful feature of `log` — they filter by any structured metadata field. Supported by `log show`, `log stream`, and `log collect`.
+
+### NSPredicate Syntax
+
+Full NSPredicate rules (see [Apple Predicate Programming Guide](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/Predicates/Articles/pSyntax.html)):
+
+**Supported keys:**
+
+| Key | Description |
+|-----|-------------|
+| `subsystem` | Reverse-DNS namespace (os_log messages only) |
+| `category` | Subdivision within a subsystem (requires subsystem) |
+| `process` | Process name |
+| `processImagePath` | Full path to process binary |
+| `sender` | Library/framework name that originated the event |
+| `senderImagePath` | Full path to originating library/framework |
+| `eventMessage` | The message text |
+| `messageType` | Log level: `default`, `info`, `debug`, `error`, `fault` |
+| `eventType` | Event type: `logEvent`, `activityCreateEvent`, etc. |
+
+**Operators:** `==`, `!=`, `CONTAINS`, `CONTAINS[cd]`, `BEGINSWITH`, `ENDSWITH`, `IN`, `&&`, `||`, `!`
+
+```bash
+# Specific subsystem
+sudo log show --last 1h --predicate 'subsystem == "com.apple.sharing"'
+
+# Subsystem + category
+sudo log show --predicate '(subsystem == "com.apple.sharing") && (category == "AirDrop")'
+
+# Multiple categories
+sudo log show --predicate '(subsystem == "com.apple.sharing") && (category IN {"AirDrop", "Bonjour"})'
+
+# Process by path suffix
+sudo log show --predicate 'processImagePath ENDSWITH "Safari"'
+
+# Message content (case-insensitive)
+sudo log show --last 1h --predicate 'eventMessage CONTAINS[ci] "timeout"'
+
+# Errors only from a process
+sudo log stream --predicate 'process == "Finder" && messageType == "error"'
+
+# Subsystem + sender framework
+sudo log show --predicate \
+    '(subsystem == "com.apple.network") && (senderImagePath CONTAINS "CFNetwork")'
+```
+
+### Shorthand Syntax
+
+A faster alternative — same `--predicate` flag, different syntax. Run `log help shorthand` for full reference.
+
+| Shorthand key | Full key equivalent |
+|--------------|---------------------|
+| `s` or `subsystem` | `subsystem` |
+| `c` or `category` | `category` |
+| `p` or `process` | `process` |
+| `pid` | process ID |
+| `type` | `messageType` |
+| `m` or message | `eventMessage` (omit key to match message) |
+
+**Operators:** `=` (equals), `!=`, `:` (contains), `!:` (not contains), `:^` (starts with), `endswith`, `~/regex/`
+
+**Values:** Use `|` as logical OR on the right side.
+
+```bash
+# Subsystem equality
+sudo log show --predicate 's=com.apple.sharing'
+
+# Category contains "network"
+sudo log stream --predicate 'c:network'
+
+# Process name, error or fault type
+sudo log stream --predicate 'p=Safari and type=error|fault'
+
+# Subsystem + category + message content
+sudo log show --last 1h \
+    --predicate 's=com.apple.sharing and c:airdrop and "connection"'
+
+# Multiple processes
+sudo log stream --predicate 'p=Safari|Finder and type=error'
+```
+
+---
+
+## Writing Logs from Shell
+
+### `logger` — BSD Syslog Interface
+
+`logger` writes entries into the unified logging system via the syslog interface. Entries appear with `process == "logger"` and are searchable.
+
+```bash
+# Basic — tag identifies the source
+logger -t "my-script" "task started"
+
+# With priority/facility
+logger -t "my-script" -p user.info "processing $# items"
+logger -t "my-script" -p user.debug "variable value: $var"
+logger -t "my-script" -p user.error "something failed: exit $?"
+
+# Also print to stderr (useful during development)
+logger -t "my-script" -s "visible in terminal AND in log"
+
+# Read from file
+logger -t "my-script" -f /tmp/output.txt
+```
+
+**Priority/facility format** `-p facility.level`:
+- Facilities: `user`, `local0`–`local7`, `daemon`, `syslog`
+- Levels: `emerg`, `alert`, `crit`, `err`, `warning`, `notice`, `info`, `debug`
+- Common: `user.info`, `user.debug`, `user.error`, `user.warning`
+
+**Finding your entries:**
+```bash
+# All logger entries from last hour
+log show --last 1h --predicate 'process=="logger"'
+
+# Your tagged entries
+log show --last 1h --predicate 'process=="logger" and eventMessage contains "my-script"'
+
+# Real-time stream of your script's logs
+log stream --predicate 'process=="logger" and eventMessage contains "my-script"'
+```
+
+> **Note on subsystem/category**: `logger` uses the BSD syslog interface and does not support `subsystem` or `category` (those are `os_log` API concepts available to Swift/C/Obj-C code). Use the `-t` tag as your identifier and filter with `eventMessage contains "your-tag"`.
+
+### `_log` — Consistent Helper Pattern for Zsh Functions
+
+A thin wrapper around `logger` for structured logging in zsh autoload functions:
+
+```zsh
+# Add to your function file or a shared autoload helper
+_log() {
+    local level="${1:-info}"; shift
+    # Use calling function name as tag, fall back to "zsh"
+    local tag="${funcstack[2]:-zsh}"
+    logger -t "$tag" -p "user.$level" "$*"
+}
+
+# Usage inside any zsh function:
+my_deploy() {
+    _log info "starting deploy to $1"
+    # ... work ...
+    _log debug "upload complete, running migrations"
+    # ... work ...
+    _log info "deploy finished"
+}
+
+# Watch in real time while it runs:
+# log stream --predicate 'process=="logger" and eventMessage contains "my_deploy"'
+```
+
+---
+
+## `log config` — Enable Debug Logging for a Subsystem
+
+> **Footnote / Advanced**: Requires root. Temporarily enables debug or info messages for a specific subsystem — useful when debugging your own app or a system component that normally only logs at default level.
+
+```bash
+# Enable debug logging for a subsystem
+sudo log config --mode "level:debug" --subsystem com.mycompany.myapp
+
+# Check current config
+sudo log config --status --subsystem com.mycompany.myapp
+
+# Reset to default after debugging
+sudo log config --reset --subsystem com.mycompany.myapp
+```
+
+Enable → reproduce the issue → collect/show → reset. Forgetting to reset leaves debug logging on system-wide for that subsystem.

--- a/plugins/terminal-guru/skills/signals-monitoring/references/notifications_guide.md
+++ b/plugins/terminal-guru/skills/signals-monitoring/references/notifications_guide.md
@@ -1,0 +1,250 @@
+# macOS Notifications Guide
+
+## Overview
+
+Send macOS user notifications from the terminal — useful for alerting yourself when long-running commands finish, monitoring scripts detect events, or build systems succeed or fail. Two approaches: native `osascript` (no dependencies) and `terminal-notifier` (richer options, Homebrew).
+
+---
+
+## Native: `osascript` Notifications
+
+No installation required. Uses AppleScript's `display notification` command.
+
+### Basic Syntax
+
+```bash
+osascript -e 'display notification "message" with title "Title"'
+```
+
+### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `"message"` | Yes | The body text |
+| `with title "..."` | No | Bold header (recommended) |
+| `subtitle "..."` | No | Secondary line below title |
+| `sound name "..."` | No | System sound to play |
+
+```bash
+# Minimal
+osascript -e 'display notification "Done"'
+
+# With title
+osascript -e 'display notification "Build finished" with title "Make"'
+
+# With subtitle and sound
+osascript -e 'display notification "All tests passed" with title "CI" subtitle "main branch" sound name "Glass"'
+
+# Failure notification
+osascript -e 'display notification "Build failed — check output" with title "Make" sound name "Basso"'
+```
+
+### Common Sound Names
+
+| Sound | Tone |
+|-------|------|
+| `Glass` | Soft success chime |
+| `Basso` | Deep failure thud |
+| `Ping` | Light alert |
+| `Purr` | Subtle purr |
+| `Sosumi` | Classic Mac alert |
+| `Blow` | Soft whoosh |
+| `Frog` | Frog croak |
+| `Pop` | Sharp pop |
+
+Browse in `/System/Library/Sounds/` — use filename without `.aiff`.
+
+### Shell Variable Interpolation
+
+Use double quotes for the outer string to interpolate variables (but escape inner quotes):
+
+```bash
+# Using shell variable in notification
+status="success"
+osascript -e "display notification \"Deploy $status\" with title \"CI\" sound name \"Glass\""
+
+# Or use heredoc for complex messages
+osascript << 'EOF'
+display notification "Build done" with title "Make" sound name "Glass"
+EOF
+```
+
+---
+
+## `terminal-notifier` — Richer Notifications
+
+More control over notification behavior, including click actions, grouping, and app activation.
+
+**Install:** `brew install terminal-notifier`
+
+### Basic Usage
+
+```bash
+terminal-notifier -title "Title" -message "Message body"
+terminal-notifier -title "Deploy" -message "Production live" -sound default
+```
+
+### Key Options
+
+| Flag | Description |
+|------|-------------|
+| `-title` | Bold notification title |
+| `-subtitle` | Secondary line |
+| `-message` | Body text (required) |
+| `-sound` | Sound name (use `default` for system default) |
+| `-group <id>` | Group ID — replaces previous notification with same ID |
+| `-activate <bundle>` | App to bring to front when clicked |
+| `-open <url>` | URL to open when notification is clicked |
+| `-execute <cmd>` | Shell command to run when clicked |
+| `-sender <bundle>` | Appear as if from another app (e.g., com.apple.Terminal) |
+| `-ignoreDnD` | Show even in Do Not Disturb mode |
+
+```bash
+# Basic with sound
+terminal-notifier -title "Tests" -message "All passing" -sound default
+
+# Click to open Terminal
+terminal-notifier -title "Build done" -message "See output" \
+    -activate com.apple.Terminal
+
+# Open a URL on click
+terminal-notifier -title "Server ready" -message "localhost:3000" \
+    -open "http://localhost:3000"
+
+# Group: replace previous notification with same group ID
+# (avoids notification spam during rapid file changes)
+terminal-notifier -title "File Watch" -message "Changed: config.yaml" \
+    -group "file-watcher"
+
+# Execute a command when clicked
+terminal-notifier -title "Deployment done" -message "Click to check logs" \
+    -execute "open -a Terminal"
+```
+
+### Checking If Installed
+
+Always fall back to `osascript` if `terminal-notifier` isn't available:
+
+```zsh
+notify() {
+    local title="$1" message="$2" sound="${3:-Glass}"
+    if command -v terminal-notifier &>/dev/null; then
+        terminal-notifier -title "$title" -message "$message" -sound default
+    else
+        osascript -e "display notification \"$message\" with title \"$title\" sound name \"$sound\""
+    fi
+}
+```
+
+---
+
+## Practical Patterns
+
+### `notify_when_done` — Wrap Any Command
+
+Run a command and send a success/failure notification when it finishes:
+
+```zsh
+# Add to ~/.zshrc or as a zsh autoload function
+notify_when_done() {
+    if [[ $# -eq 0 ]]; then
+        echo "Usage: notify_when_done <command> [args...]" >&2
+        return 1
+    fi
+
+    local cmd_display="$*"
+    "$@"
+    local status=$?
+
+    if (( status == 0 )); then
+        osascript -e "display notification \"$cmd_display\" \
+            with title \"Done ✓\" sound name \"Glass\""
+    else
+        osascript -e "display notification \"$cmd_display (exit $status)\" \
+            with title \"Failed ✗\" sound name \"Basso\""
+    fi
+
+    return $status
+}
+
+# Usage:
+notify_when_done make build
+notify_when_done swift test
+notify_when_done kubectl apply -f k8s/production.yaml
+notify_when_done npm run build
+```
+
+### Notify After Long Command (Append Style)
+
+Add to end of a one-off command without a wrapper function:
+
+```bash
+# Append && notification for success
+make build && osascript -e 'display notification "Build OK" with title "Make" sound name "Glass"'
+
+# Notify regardless of outcome
+make build; osascript -e "display notification \"exit $?\" with title \"Make\""
+
+# Full success/failure in one line
+make build \
+    && osascript -e 'display notification "Build OK" with title "Make" sound name "Glass"' \
+    || osascript -e 'display notification "Build FAILED" with title "Make" sound name "Basso"'
+```
+
+### Notify When a Process Finishes
+
+```zsh
+notify_pid() {
+    local pid="$1"
+    local label="${2:-Process $pid}"
+    if ! kill -0 "$pid" 2>/dev/null; then
+        echo "PID $pid not found" >&2
+        return 1
+    fi
+    # Wait for process to finish
+    while kill -0 "$pid" 2>/dev/null; do sleep 2; done
+    osascript -e "display notification \"$label finished\" with title \"Done\" sound name \"Glass\""
+}
+
+# Usage: start something, get its PID, then watch it
+./long_running_script.sh &
+notify_pid $! "long_running_script"
+```
+
+### Notify from File Watcher
+
+```bash
+# fswatch + notification on change (with terminal-notifier grouping)
+fswatch ./src | while read file; do
+    terminal-notifier \
+        -title "File Changed" \
+        -message "$(basename "$file")" \
+        -group "fswatch-src"
+done
+```
+
+### Scheduled or Delayed Notification
+
+```bash
+# Notify in 30 minutes (reminder)
+(sleep 1800 && osascript -e 'display notification "Time check!" with title "Reminder"') &
+
+# At a specific time using `at` (if enabled)
+echo 'osascript -e "display notification \"Meeting!\" with title \"Calendar\""' | at 14:30
+```
+
+---
+
+## Notification Center Permissions
+
+If notifications don't appear, check System Settings → Notifications → Terminal (or the app running the command).
+
+```bash
+# Test if notifications are working
+osascript -e 'display notification "Test notification" with title "Test" sound name "Ping"'
+```
+
+If the notification appears but silently, check:
+- System Settings → Notifications → [App] → Alert style (set to "Banners" or "Alerts")
+- Focus / Do Not Disturb mode
+- For `terminal-notifier`: it may need to be run once manually to request permission

--- a/plugins/terminal-guru/skills/signals-monitoring/references/signals_guide.md
+++ b/plugins/terminal-guru/skills/signals-monitoring/references/signals_guide.md
@@ -1,0 +1,278 @@
+# Unix Signals Guide
+
+## Overview
+
+Signals are asynchronous notifications sent to a process by the kernel, another process, or the user (e.g., Ctrl+C). Every Unix process can receive signals, and shell scripts can intercept them with `trap` to perform cleanup or change behavior.
+
+Understanding signals is essential for:
+- Writing shell scripts that clean up temp files and locks reliably
+- Implementing graceful shutdown in long-running functions
+- Sending reload signals to daemons without restarting them
+- Handling broken pipes in shell pipelines
+
+---
+
+## Signal Reference
+
+Core signals you'll encounter in terminal and shell work:
+
+| Signal | Number | Default action | Catchable? | Common use |
+|--------|--------|---------------|-----------|------------|
+| `SIGHUP` | 1 | Terminate | Yes | Terminal closed; conventionally: reload config |
+| `SIGINT` | 2 | Terminate | Yes | Ctrl+C — user interrupt |
+| `SIGQUIT` | 3 | Core dump | Yes | Ctrl+\ — quit with core dump |
+| `SIGKILL` | 9 | Terminate | **No** | Force kill — cannot be caught or ignored |
+| `SIGTERM` | 15 | Terminate | Yes | Graceful shutdown request (default for `kill`) |
+| `SIGSTOP` | 19 | Stop | **No** | Ctrl+Z — pause process (cannot be caught) |
+| `SIGCONT` | 18 | Continue | Yes | Resume a stopped process (`fg`, `bg`) |
+| `SIGPIPE` | 13 | Terminate | Yes | Write to a broken pipe |
+| `SIGUSR1` | 30 | Terminate | Yes | App-defined — custom use |
+| `SIGUSR2` | 31 | Terminate | Yes | App-defined — custom use |
+| `SIGCHLD` | 20 | Ignore | Yes | Child process stopped or terminated |
+| `SIGWINCH` | 28 | Ignore | Yes | Terminal window resized |
+
+> `SIGKILL` (9) and `SIGSTOP` (19) cannot be caught, blocked, or ignored. They always succeed.
+
+---
+
+## Sending Signals
+
+### `kill` — Send Signal by PID
+
+```bash
+# Default signal is SIGTERM (15) — graceful shutdown request
+kill <pid>
+kill -TERM <pid>    # same as above, explicit
+
+# Force kill — use only when SIGTERM doesn't work
+kill -KILL <pid>
+kill -9 <pid>       # numeric form
+
+# Reload config (nginx, sshd, launchd agents, etc.)
+kill -HUP <pid>
+kill -1 <pid>
+
+# Send SIGUSR1 (app-defined)
+kill -USR1 <pid>
+
+# Send to multiple PIDs
+kill -TERM 1234 5678
+
+# Signal by name or number — both work
+kill -s TERM <pid>
+kill -s 15 <pid>
+```
+
+### `pkill` / `pgrep` — Signal by Name
+
+```bash
+# Find PIDs by process name
+pgrep nginx               # list matching PIDs
+pgrep -l nginx            # list with names
+
+# Send signal to matching processes
+pkill nginx               # SIGTERM to all nginx processes
+pkill -HUP nginx          # reload all nginx workers
+pkill -9 -f "python my_script.py"   # -f matches full command line
+
+# Confirm what would be killed first
+pgrep -l -f "my pattern"
+```
+
+### `killall` — Signal by Name (macOS)
+
+```bash
+killall Safari            # SIGTERM to all processes named "Safari"
+killall -HUP sshd         # reload sshd config
+killall -9 Finder         # force kill Finder (it will relaunch)
+```
+
+### Job Control Signals
+
+```bash
+# Pause a foreground process (sends SIGSTOP)
+Ctrl+Z
+
+# Resume in background
+bg
+
+# Resume in foreground
+fg
+
+# List jobs
+jobs
+
+# Send signal to job by job number
+kill -TERM %1    # job 1
+kill %2          # SIGTERM to job 2
+```
+
+---
+
+## `trap` — Intercepting Signals in Shell Scripts
+
+`trap` registers a command to run when the shell receives a signal. Essential for cleanup in any script that creates temp files, holds locks, or spawns background processes.
+
+### Syntax
+
+```zsh
+trap 'command_or_function' SIGNAL [SIGNAL...]
+trap - SIGNAL          # reset to default behavior
+trap '' SIGNAL         # explicitly ignore the signal
+```
+
+**Pseudo-signals** (not real Unix signals, but handled by trap):
+- `EXIT` — fires when the shell exits for any reason (normal exit, signal, error)
+- `ERR` — fires when a command returns non-zero (bash only, not reliably in zsh)
+- `DEBUG` — fires before each command
+
+### Pattern 1: Cleanup on Exit
+
+The most important pattern. `EXIT` fires on Ctrl+C, SIGTERM, and normal exit — use it for all cleanup:
+
+```zsh
+#!/usr/bin/env zsh
+
+# Create temp resources
+tmpfile=$(mktemp)
+lockfile="/tmp/my-script.lock"
+touch "$lockfile"
+
+# Register cleanup — runs no matter how the script exits
+trap 'rm -f "$tmpfile" "$lockfile"' EXIT
+
+# ... rest of script ...
+# Cleanup happens automatically
+```
+
+### Pattern 2: Graceful Shutdown with Message
+
+```zsh
+#!/usr/bin/env zsh
+
+cleanup() {
+    echo "Shutting down..." >&2
+    # stop background jobs, flush buffers, etc.
+    kill $(jobs -p) 2>/dev/null
+    wait
+}
+
+trap 'cleanup; exit 130' INT    # 130 = 128 + SIGINT(2)
+trap 'cleanup; exit 143' TERM   # 143 = 128 + SIGTERM(15)
+trap 'cleanup' EXIT             # also runs on normal exit
+```
+
+### Pattern 3: Config Reload on SIGHUP
+
+```zsh
+#!/usr/bin/env zsh
+
+CONFIG_FILE="$HOME/.myconfig"
+load_config() { source "$CONFIG_FILE" }
+
+load_config  # initial load
+
+trap 'load_config; echo "config reloaded"' HUP
+
+# Long-running loop
+while true; do
+    do_work
+    sleep 5
+done
+```
+
+Trigger reload from another terminal: `kill -HUP <pid>`
+
+### Pattern 4: Ignore SIGPIPE
+
+When a script writes to a pipeline where the reader exits early:
+
+```zsh
+# Suppress SIGPIPE — prevents "write error: Broken pipe" messages
+trap '' PIPE
+
+# Example: head exits after 10 lines, but the producer keeps running
+produce_output | head -10
+```
+
+### Pattern 5: Long-Running Zsh Autoload Function with Cleanup
+
+The canonical pattern for any autoload function that runs indefinitely:
+
+```zsh
+# File: ~/.zsh/functions/my_watcher
+my_watcher() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+
+    # Cleanup fires on Ctrl+C, kill, or normal return
+    trap "rm -rf '$tmpdir'; trap - INT TERM EXIT; return 0" INT TERM EXIT
+
+    echo "Watching... (Ctrl+C to stop)"
+    while true; do
+        # ... do work using $tmpdir ...
+        sleep 2
+    done
+}
+
+my_watcher "$@"
+```
+
+Key details:
+- `trap - INT TERM EXIT` inside the handler resets traps before returning, preventing double-execution
+- `return 0` (not `exit 0`) is correct inside a function
+- `trap` inside a function is local to the function's execution context in zsh
+
+### Pattern 6: Nested Traps / Saving and Restoring
+
+```zsh
+# Save existing trap, set new one, restore after
+old_trap=$(trap -p INT)
+trap 'echo "custom handler"' INT
+# ... do sensitive work ...
+eval "$old_trap"   # restore original trap
+```
+
+---
+
+## Common Daemon Reload Patterns
+
+Services that respond to SIGHUP by reloading their config (without restart):
+
+```bash
+# nginx
+sudo kill -HUP $(cat /var/run/nginx.pid)
+# or
+sudo pkill -HUP nginx
+
+# sshd
+sudo kill -HUP $(pgrep sshd)
+
+# launchd-managed services — use launchctl instead
+sudo launchctl kickstart -k system/com.apple.sshd
+```
+
+---
+
+## Signal Propagation and Background Jobs
+
+```bash
+# Kill a process group (process + all children)
+kill -TERM -<pgid>    # negative PID = process group ID
+
+# Find process group
+ps -o pgid= -p <pid>
+
+# Kill all children of a script
+trap 'kill 0' EXIT    # kill the entire process group on exit
+```
+
+```zsh
+# In a script, wait for background jobs and forward signals
+child_pid=""
+long_running_command &
+child_pid=$!
+
+trap 'kill -TERM "$child_pid" 2>/dev/null; wait "$child_pid"' INT TERM EXIT
+wait "$child_pid"
+```

--- a/plugins/terminal-guru/skills/signals-monitoring/scripts/logwatch
+++ b/plugins/terminal-guru/skills/signals-monitoring/scripts/logwatch
@@ -1,0 +1,49 @@
+#autoload
+#!/usr/bin/env zsh
+#
+# logwatch — open a filtered macOS log stream in a tmux pane (or current terminal)
+#
+# Usage:
+#   logwatch [subsystem]              Stream by subsystem (e.g. com.apple.sharing)
+#   logwatch "" [predicate]           Stream by raw NSPredicate/shorthand predicate
+#   logwatch                          Stream all log events (unfiltered, noisy)
+#
+# When inside tmux, opens a new horizontal split pane.
+# When outside tmux, streams in the current terminal (Ctrl+C to stop).
+#
+# Install as a zsh autoload function:
+#   bash /path/to/zsh-dev/scripts/install_autoload.sh logwatch /path/to/this/file
+#
+# Examples:
+#   logwatch com.apple.sharing
+#   logwatch com.apple.network
+#   logwatch "" "process==\"Safari\" and type=error"
+#   logwatch "" "s=com.myapp and type=error|fault"
+
+logwatch() {
+    local subsystem="${1:-}"
+    local predicate="${2:-}"
+
+    # Build predicate string from subsystem shorthand if only subsystem given
+    if [[ -n "$subsystem" && -z "$predicate" ]]; then
+        predicate="subsystem==\"${subsystem}\""
+    fi
+
+    # Build the log stream command
+    local cmd="sudo log stream --level debug --style compact"
+    if [[ -n "$predicate" ]]; then
+        cmd+=" --predicate '${predicate}'"
+    fi
+
+    if [[ -n "$TMUX" ]]; then
+        # Open in a new tmux split pane below
+        tmux split-window -v "$cmd"
+    else
+        # Fall back to streaming in the current terminal
+        echo "Not in tmux — streaming in current terminal. Press Ctrl+C to stop." >&2
+        echo "Command: $cmd" >&2
+        eval "$cmd"
+    fi
+}
+
+logwatch "$@"

--- a/plugins/terminal-guru/skills/zsh-dev/references/zsh_function_patterns.md
+++ b/plugins/terminal-guru/skills/zsh-dev/references/zsh_function_patterns.md
@@ -9,6 +9,7 @@ Comprehensive guide to zsh function development patterns, combining user's prefe
 3. [Completion Patterns](#completion-patterns)
 4. [macOS Keychain Security](#macos-keychain-security)
 5. [Structured Documentation Standard](#structured-documentation-standard)
+6. [Logging from Zsh Functions](#logging-from-zsh-functions)
 
 ---
 
@@ -468,6 +469,43 @@ Choose your pattern based on needs:
 | Store/retrieve secrets | Credential Security | Medium |
 | Complex argument parsing | `_arguments` | Medium |
 | Multiple subcommands | Subcommand with State | Medium |
+
+---
+
+## Logging from Zsh Functions
+
+> **Full coverage in signals-monitoring skill** — see `skills/signals-monitoring/references/macos_logging_guide.md` for the complete `logger` reference and predicate filtering guide.
+
+When your zsh function needs to emit structured, searchable log entries to macOS's unified logging system, use `logger` with the `_log` helper pattern:
+
+```zsh
+# _log helper — include in your function file or a shared autoload
+_log() {
+    local level="${1:-info}"; shift
+    local tag="${funcstack[2]:-zsh}"   # use calling function name as tag
+    logger -t "$tag" -p "user.$level" "$*"
+}
+
+# Usage inside any autoload function:
+my_deploy() {
+    _log info "starting deploy to $1"
+    # ... work ...
+    _log debug "step complete"
+    _log info "deploy finished"
+}
+
+# Find your entries:
+# log show --last 1h --predicate 'process=="logger" and eventMessage contains "my_deploy"'
+# log stream --predicate 'process=="logger" and eventMessage contains "my_deploy"'
+```
+
+**Key points:**
+- `logger` writes into the macOS unified log — no separate log file needed
+- Use `-t <tag>` (matches function name via `_log`) for filtering
+- Levels: `user.debug`, `user.info`, `user.warning`, `user.error`
+- Add `-s` to also print to stderr during development
+
+For signal/trap patterns in long-running functions, see `skills/signals-monitoring/references/signals_guide.md`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Added `signals-monitoring` as a 3rd skill in the terminal-guru plugin
- Covers macOS unified logging, Unix process signals, file watching, and notifications
- Includes `logwatch` — a tmux-aware zsh autoload function for filtered live log streams
- Updated agent routing, plugin.json (v4.0.0), and README

## What's included

| Component | Coverage |
|---|---|
| `SKILL.md` | All 4 domains, trigger phrases, dtrace future note |
| `references/macos_logging_guide.md` | log show/stream/collect/stats, NSPredicate + shorthand filtering, logger/_log pattern |
| `references/signals_guide.md` | Signal table, kill/pkill, trap patterns (EXIT/TERM/INT/HUP/PIPE), long-running function template |
| `references/file_watching_guide.md` | fswatch, entr, pgrep, lsof, process inspection |
| `references/notifications_guide.md` | osascript, terminal-notifier, notify_when_done pattern |
| `scripts/logwatch` | Zsh autoload function — tmux split pane with filtered log stream |
| Agent routing | 7 new signals-monitoring rows added |
| plugin.json | Bumped to 4.0.0, added keywords |

## Skillsmith Evaluation

**88/100** — description 100/100, progressive disclosure 100/100, complexity 90/100

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is documentation/skill content only — no runtime code, services, or infrastructure changes.

## Closes

Closes #86

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)