### PR TITLE
feat(omnifocus-manager): v6.5.0 — ofo: slash commands + omnifocus:// URL directive

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -84,7 +84,7 @@
       "name": "omnifocus-manager",
       "description": "Interface with OmniFocus to surface insights, create reusable automations and perspectives, and suggest workflow optimizations",
       "category": "productivity",
-      "version": "6.4.1",
+      "version": "6.5.0",
       "author": {
         "name": "J. Greg Williams",
         "email": "283704+totallyGreg@users.noreply.github.com"

--- a/plugins/omnifocus-manager/.claude-plugin/plugin.json
+++ b/plugins/omnifocus-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omnifocus-manager",
-  "version": "6.4.1",
+  "version": "6.5.0",
   "description": "Query and manage OmniFocus tasks through database queries and JavaScript for Automation (JXA), with GTD methodology coaching.",
   "author": {
     "name": "J. Greg Williams",

--- a/plugins/omnifocus-manager/agents/omnifocus-agent.md
+++ b/plugins/omnifocus-manager/agents/omnifocus-agent.md
@@ -114,12 +114,18 @@ Classify each user request and route accordingly:
 | "Help me do my weekly review" | Both | gtd-coach walks checklist, omnifocus-manager runs queries |
 | "Are my projects healthy?" | Both | gtd-coach for principles, `gtd-queries.js --action system-health` for data |
 | "Improve my next action names" | Both | gtd-coach for clarity rules, omnifocus-manager to update |
-| "Analyze my repeating tasks / habits" | omnifocus-manager | `gtd-queries.js --action repeating-tasks` (or `/of:analyze-habits`) |
-| "Which habits am I not doing?" | omnifocus-manager | `gtd-queries.js --action repeating-tasks` (or `/of:analyze-habits`) |
-| "Sweep my projects for issues" | omnifocus-manager | `gtd-queries.js --action analyze-projects` (or `/of:analyze-projects`) |
-| "Find duplicate projects" | omnifocus-manager | `gtd-queries.js --action analyze-projects` (or `/of:analyze-projects`) |
-| "Clarify / expound on this task" | omnifocus-manager | `/of:expound` command |
-| "Name this task better / add tags" | omnifocus-manager | `/of:expound` command |
+| "Analyze my repeating tasks / habits" | omnifocus-manager | `gtd-queries.js --action repeating-tasks` (or `/ofo:analyze-habits`) |
+| "Which habits am I not doing?" | omnifocus-manager | `gtd-queries.js --action repeating-tasks` (or `/ofo:analyze-habits`) |
+| "Sweep my projects for issues" | omnifocus-manager | `gtd-queries.js --action analyze-projects` (or `/ofo:analyze-projects`) |
+| "Find duplicate projects" | omnifocus-manager | `gtd-queries.js --action analyze-projects` (or `/ofo:analyze-projects`) |
+| "Clarify / expound on this task" | omnifocus-manager | `/ofo:expound` command |
+| "Name this task better / add tags" | omnifocus-manager | `/ofo:expound` command |
+| `omnifocus://` URL pasted | omnifocus-manager | `/ofo:info <url>` — parse ID and look up entity |
+| "What's due today?" / "Today's tasks" | omnifocus-manager | `/ofo:today` command |
+| "Show my inbox" | omnifocus-manager | `/ofo:inbox` command |
+| "Show overdue tasks" | omnifocus-manager | `/ofo:overdue` command |
+| "How's my system?" / "Quick health check" | omnifocus-manager | `/ofo:health` command |
+| "Search for task <name>" | omnifocus-manager | `/ofo:search <term>` command |
 
 ## Routing Logic
 
@@ -150,6 +156,16 @@ For requests requiring both skills:
 7. [omnifocus-manager] osascript -l JavaScript scripts/gtd-queries.js --action waiting-for     → aging waiting items
 8. [omnifocus-manager] osascript -l JavaScript scripts/gtd-queries.js --action system-health   → overall GTD health
 9. [gtd-coach] Prompt creative brainstorming based on health data
+```
+
+**Example: omnifocus:// URL Pasted**
+
+```
+User pastes: omnifocus:///task/abc123XYZ
+→ Route to: /ofo:info omnifocus:///task/abc123XYZ
+→ Parse ID: abc123XYZ
+→ manage_omnifocus.js task-info --id abc123XYZ
+→ Present task details
 ```
 
 **Example: Inbox Processing Flow**

--- a/plugins/omnifocus-manager/commands/ofo-analyze-habits.md
+++ b/plugins/omnifocus-manager/commands/ofo-analyze-habits.md
@@ -5,7 +5,7 @@ allowed-tools: Bash(osascript:*), Bash(${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-ma
 ---
 
 <!--
-/of:analyze-habits - Habit cadence analysis for repeating tasks.
+/ofo:analyze-habits - Habit cadence analysis for repeating tasks.
 Pulls all repeating tasks and their completion history, computes actual
 vs intended gap days, and gives concrete defer/due recommendations.
 -->

--- a/plugins/omnifocus-manager/commands/ofo-analyze-projects.md
+++ b/plugins/omnifocus-manager/commands/ofo-analyze-projects.md
@@ -5,7 +5,7 @@ allowed-tools: Bash(osascript:*), Bash(${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-ma
 ---
 
 <!--
-/of:analyze-projects - Project health sweep.
+/ofo:analyze-projects - Project health sweep.
 Detects stalled projects, neglected projects, overdue task accumulation,
 and near-duplicate project names that may represent fragmented capture.
 -->

--- a/plugins/omnifocus-manager/commands/ofo-expound.md
+++ b/plugins/omnifocus-manager/commands/ofo-expound.md
@@ -5,7 +5,7 @@ allowed-tools: Bash(osascript:*), Bash(${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-ma
 ---
 
 <!--
-/of:expound - Expound on a task or project.
+/ofo:expound - Expound on a task or project.
 Fetches current name, note, tags, and duration estimate. Suggests a clearer
 action-oriented name, verifies effort/duration tags, and applies confirmed
 changes via manage_omnifocus.js.

--- a/plugins/omnifocus-manager/commands/ofo-health.md
+++ b/plugins/omnifocus-manager/commands/ofo-health.md
@@ -1,0 +1,24 @@
+---
+description: Show OmniFocus system health — inbox, overdue, stalled, and waiting counts
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager/scripts/*)
+---
+
+<!--
+/ofo:health - Quick GTD system health check.
+Runs system-health query and presents a one-line status plus any warnings.
+-->
+
+System health:
+!`cd "${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager" && osascript -l JavaScript scripts/gtd-queries.js --action system-health`
+
+Present the health data as:
+
+**System Health:** `Inbox: N | Overdue: N | Stalled: N | Waiting: N`
+
+Then flag any counts that need attention:
+- Inbox > 0 → "Process your inbox"
+- Overdue > 10 → "High overdue count — consider a review"
+- Stalled > 3 → "Several stalled projects need attention"
+- Waiting aging > 20 → "Many aging Waiting items — review and drop or follow up"
+
+If all counts are healthy, say: "System looks healthy. ✓"

--- a/plugins/omnifocus-manager/commands/ofo-inbox.md
+++ b/plugins/omnifocus-manager/commands/ofo-inbox.md
@@ -1,0 +1,20 @@
+---
+description: Show and process OmniFocus inbox items
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager/scripts/*)
+---
+
+<!--
+/ofo:inbox - Show OmniFocus inbox items.
+Fetches inbox count and items, presents each with a GTD clarify decision.
+-->
+
+Inbox items:
+!`cd "${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager" && osascript -l JavaScript scripts/gtd-queries.js --action inbox-count`
+
+Present the inbox items above as a table: **Item | GTD Decision | Notes**
+
+Apply the GTD clarify decision tree to each item:
+- Actionable → Next Action (assign project) or Project (if multi-step)
+- Not actionable → Someday/Maybe, Reference, or Trash
+
+If inbox is empty, say: "Inbox is at zero. ✓"

--- a/plugins/omnifocus-manager/commands/ofo-info.md
+++ b/plugins/omnifocus-manager/commands/ofo-info.md
@@ -1,0 +1,43 @@
+---
+description: Look up an OmniFocus task or project by ID or omnifocus:// URL
+argument-hint: [task-id or omnifocus:// URL]
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager/scripts/*)
+---
+
+<!--
+/ofo:info - Look up a task or project by ID or omnifocus:// URL.
+Parses omnifocus:///task/<id> and omnifocus:///project/<id> URL schemes.
+Fetches full details and presents them in a readable summary.
+-->
+
+## Step 1: Parse the ID
+
+The argument is: `$ARGUMENTS`
+
+If `$ARGUMENTS` starts with `omnifocus://`, extract the entity ID:
+- `omnifocus:///task/<id>` → task ID is `<id>`
+- `omnifocus:///project/<id>` → project ID is `<id>` (use project-info)
+- `omnifocus:///folder/<id>` → folder ID
+
+If `$ARGUMENTS` is a bare ID (no `://`), treat it as a task ID.
+
+## Step 2: Fetch Details
+
+For a task ID:
+```bash
+cd "${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager" && osascript -l JavaScript scripts/manage_omnifocus.js task-info --id "<id>"
+```
+
+For a project ID:
+```bash
+cd "${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager" && osascript -l JavaScript scripts/manage_omnifocus.js project-info --id "<id>"
+```
+
+## Step 3: Present
+
+Show the details in a clean summary:
+- **Name**, Project, Tags, Due, Defer, Estimated time
+- Note content (if any)
+- For projects: task count, completion status
+
+If no ID provided or lookup fails, say: "Provide a task ID or `omnifocus://` URL as an argument."

--- a/plugins/omnifocus-manager/commands/ofo-overdue.md
+++ b/plugins/omnifocus-manager/commands/ofo-overdue.md
@@ -1,0 +1,24 @@
+---
+description: Show overdue tasks grouped by category with recommended actions
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager/scripts/*)
+---
+
+<!--
+/ofo:overdue - Show overdue tasks.
+Fetches all overdue tasks and presents them grouped by type with recommended actions.
+Ghost recurrences (same name, multiple instances) are flagged for batch-complete.
+-->
+
+Overdue tasks:
+!`cd "${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager" && osascript -l JavaScript scripts/manage_omnifocus.js overdue`
+
+Present the overdue tasks above as a table: **Task | Project | Days Overdue | Recommended Action**
+
+Group by:
+- 🔁 **Routine Decay** — tasks tagged Routine with multiple instances of the same name (flag with 🔁, recommend batch-complete)
+- **Work** — tasks in work projects
+- **Health** — tasks tagged Self Maintenance or in Health projects
+- **Financial** — tasks in financial projects
+- **Personal** — everything else
+
+If no overdue tasks, say: "No overdue tasks. ✓"

--- a/plugins/omnifocus-manager/commands/ofo-plan.md
+++ b/plugins/omnifocus-manager/commands/ofo-plan.md
@@ -4,7 +4,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager/scripts/*), B
 ---
 
 <!--
-/of:plan - Publish a plan document to OmniFocus and/or GitHub Issues.
+/ofo:plan - Publish a plan document to OmniFocus and/or GitHub Issues.
 Reads a plan markdown file, extracts phases and tasks, creates an OmniFocus
 project with action groups tagged AI Agent / Claude Code.
 -->
@@ -132,4 +132,4 @@ Report what was created:
 - OmniFocus project name, task count, and tag structure
 - GitHub issue URL (if created)
 - Mapping file location
-- Remind user they can use `/of:work` to execute tasks from the OmniFocus project
+- Remind user they can use `/ofo:work` to execute tasks from the OmniFocus project

--- a/plugins/omnifocus-manager/commands/ofo-search.md
+++ b/plugins/omnifocus-manager/commands/ofo-search.md
@@ -1,0 +1,18 @@
+---
+description: Search OmniFocus tasks and projects by name
+argument-hint: [search term]
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager/scripts/*)
+---
+
+<!--
+/ofo:search - Search OmniFocus tasks by name.
+Runs a text search and presents matching tasks with project context.
+-->
+
+Search results for "$ARGUMENTS":
+!`cd "${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager" && osascript -l JavaScript scripts/manage_omnifocus.js search --query "$ARGUMENTS"`
+
+Present the matching tasks as a table: **Task | Project | Due | Tags**
+
+If no results, say: "No tasks found matching '$ARGUMENTS'."
+If no search term provided, say: "Provide a search term as an argument, e.g. `/ofo:search end of day`"

--- a/plugins/omnifocus-manager/commands/ofo-today.md
+++ b/plugins/omnifocus-manager/commands/ofo-today.md
@@ -1,0 +1,19 @@
+---
+description: Show today's flagged and due tasks from OmniFocus
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager/scripts/*)
+---
+
+<!--
+/ofo:today - Show today's tasks.
+Fetches flagged and due-today tasks from OmniFocus and presents them in a clean list.
+-->
+
+Today's tasks:
+!`cd "${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager" && osascript -l JavaScript scripts/manage_omnifocus.js today`
+
+Present the JSON output above as a clean task list grouped by:
+- **Due Today** — tasks with a dueDate of today
+- **Flagged** — tasks marked flagged (deduplicate with Due Today)
+
+For each task show: task name, project, and estimated time (if set).
+If the list is empty, say: "Nothing due or flagged for today."

--- a/plugins/omnifocus-manager/commands/ofo-work.md
+++ b/plugins/omnifocus-manager/commands/ofo-work.md
@@ -4,7 +4,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/skills/omnifocus-manager/scripts/*), B
 ---
 
 <!--
-/of:work - Agent-driven task execution from an OmniFocus AI Agent project.
+/ofo:work - Agent-driven task execution from an OmniFocus AI Agent project.
 Queries for AI Agent-tagged projects, presents selection, reads tasks in order,
 implements step-by-step, marks each complete in OmniFocus.
 -->

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/IMPROVEMENT_PLAN.md
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/IMPROVEMENT_PLAN.md
@@ -4,6 +4,7 @@
 
 | Version | Date | Issue | Summary | Conc | Comp | Spec | Disc | Overall |
 |---------|------|-------|---------|------|------|------|------|---------|
+| 6.5.0 | 2026-03-08 | [#84](https://github.com/totallyGreg/claude-mp/issues/84) | Add 6 ofo: slash commands (today, inbox, overdue, info, health, search); rename 5 of: commands to ofo: prefix; omnifocus:// URL directive in SKILL.md + agent routing | 83 | 88 | 90 | 100 | 91 |
 | 6.4.1 | 2026-03-08 | - | Fix getOverdueTasks: use effectivelyCompleted/effectivelyDropped to exclude tasks in dropped/completed projects; eliminates false positives from archived recurring tasks | - | - | - | - | - |
 | 6.4.0 | 2026-03-07 | [#90](https://github.com/totallyGreg/claude-mp/issues/90) | Phase 1 GTD analysis commands: repeating-tasks + analyze-projects in gtd-queries.js; habit cadence math (RRULE parsing, gapRatio, stdDev) in taskQuery.js; /of:analyze-habits, /of:analyze-projects, /of:expound slash commands; agent routing updates | 83 | 88 | 90 | 100 | 91 |
 | 6.3.0 | 2026-03-07 | - | Rewrite foundation_models_integration.md with accurate API docs: macOS 26 requirement, LanguageModel.Session, Schema.fromJSON (arrayOf/anyOf/isOptional/maximumElements), GenerationOptions, async pattern, per-call session pattern; remove Shortcuts bridge speculation; update SKILL.md references | 83 | 88 | 90 | 100 | 91 |

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/SKILL.md
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: omnifocus-manager
 description: |
-  This skill should be used when working with OmniFocus data, running GTD diagnostics, configuring perspectives, or generating OmniFocus plugins. Triggers when user asks "show tasks", "overdue items", "check inbox", "stalled projects", "waiting for list", "someday maybe", "GTD health check", "create a plugin", "analyze OmniFocus", "AI Agent tasks", "publish plan to OmniFocus", "set up perspectives", "perspective inventory", "configure perspective", or "missing perspectives". For pure GTD methodology coaching, use the gtd-coach skill instead.
+  This skill should be used when working with OmniFocus data, running GTD diagnostics, configuring perspectives, or generating OmniFocus plugins. Triggers when user asks "show tasks", "overdue items", "check inbox", "stalled projects", "waiting for list", "someday maybe", "GTD health check", "create a plugin", "analyze OmniFocus", "AI Agent tasks", "publish plan to OmniFocus", "set up perspectives", "perspective inventory", "configure perspective", or "missing perspectives". Also triggers when the user pastes an `omnifocus://` URL — parse the entity type and ID from the URL, then use `/ofo:info <url>` to look it up directly. For pure GTD methodology coaching, use the gtd-coach skill instead.
 
   WORKFLOW: 1) CLASSIFY query vs plugin 2) SELECT format (solitary/solitary-fm/bundle/solitary-library) 3) COMPOSE from libraries 4) GENERATE via `node scripts/generate_plugin.js` - NEVER Write/Edit tools 5) VALIDATE via `bash scripts/validate-plugin.sh` 6) TEST in OmniFocus.
 metadata:
-  version: 6.4.1
+  version: 6.5.0
   author: totally-tools
   license: MIT
 compatibility:


### PR DESCRIPTION
## Summary

- Rename 5 existing `of:` commands to `ofo:` prefix (`of-plan`, `of-work`, `of-analyze-habits`, `of-analyze-projects`, `of-expound`)
- Add 6 new lightweight `ofo:` slash commands: `today`, `inbox`, `overdue`, `info`, `health`, `search`
- `ofo:info` parses `omnifocus://` URLs directly — pasting a URL now routes to the skill instead of spawning a full agent
- Update SKILL.md description with `omnifocus://` URL trigger
- Update agent routing table: `of:` → `ofo:`, URL routing row, new command entries

Closes #84

## New Commands

| Command | Script | Purpose |
|---------|--------|---------|
| `/ofo:today` | `manage_omnifocus.js today` | Flagged + due-today tasks |
| `/ofo:inbox` | `gtd-queries.js --action inbox-count` | Inbox with GTD decisions |
| `/ofo:overdue` | `manage_omnifocus.js overdue` | Overdue grouped by category |
| `/ofo:info <url-or-id>` | `manage_omnifocus.js task-info/project-info` | Look up by ID or `omnifocus://` URL |
| `/ofo:health` | `gtd-queries.js --action system-health` | One-line system health snapshot |
| `/ofo:search <term>` | `manage_omnifocus.js search` | Search tasks by name |

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: all changes are local slash commands and routing metadata with no persistent state or external side effects.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>