### PR TITLE
feat(omnifocus-manager): add tag URL support to ofo info

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -84,7 +84,7 @@
       "name": "omnifocus-manager",
       "description": "Interface with OmniFocus to surface insights, create reusable automations and perspectives, and suggest workflow optimizations",
       "category": "productivity",
-      "version": "7.3.0",
+      "version": "7.4.0",
       "author": {
         "name": "J. Greg Williams",
         "email": "283704+totallyGreg@users.noreply.github.com"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A comprehensive marketplace for Claude Code extensions, providing plugins with s
 
 | Plugin | Version | Description |
 |--------|---------|-------------|
-| **omnifocus-manager** | 7.3.0 | Interface with OmniFocus to surface insights, create reusable automations and perspectives, and suggest workflow optimizations |
+| **omnifocus-manager** | 7.4.0 | Interface with OmniFocus to surface insights, create reusable automations and perspectives, and suggest workflow optimizations |
 | **pkm-plugin** | 1.6.0 | Personal Knowledge Management expert for Obsidian vaults with dual-skill architecture: vault-architect (create structures) and vault-curator (evolve content) |
 
 ### Security (1 plugin)

--- a/docs/plans/2026-03-09-feat-ofo-info-tag-url-support-plan.md
+++ b/docs/plans/2026-03-09-feat-ofo-info-tag-url-support-plan.md
@@ -1,0 +1,114 @@
+---
+title: "ofo info: add tag URL support (omnifocus:///tag/)"
+type: feat
+status: completed
+date: 2026-03-09
+issue: "#99"
+---
+
+# ofo info: add tag URL support (omnifocus:///tag/)
+
+`ofo info omnifocus:///tag/<id>` currently fails with `"Task not found"` because `detect_type_from_url` defaults to `"task"` for any URL that isn't a project, then `Task.byIdentifier()` returns nothing.
+
+## Problem Statement
+
+The `detect_type_from_url` function in `scripts/ofo` only recognises `omnifocus:///project/*`. Anything else (including `///tag/`) falls through to `"task"`. The `ofo-info.js` Omni Automation action then calls `Task.byIdentifier(tagId)` and fails.
+
+Discovered when resolving `omnifocus:///tag/fjyi9aLKyru` (the AI Agent 🤖 tag) — had to fall back to inline JXA.
+
+## Proposed Solution
+
+Two-file change:
+
+1. **`scripts/ofo`** — extend `detect_type_from_url` to return `"tag"` for `omnifocus:///tag/*` URLs
+2. **`scripts/omni-actions/ofo-info.js`** — add a `"tag"` branch that uses `Tag.byIdentifier()` and returns tag metadata + active task list
+
+## Implementation
+
+### `scripts/ofo` — `detect_type_from_url` (lines 45–52)
+
+```bash
+detect_type_from_url() {
+  local input="$1"
+  if [[ "$input" == omnifocus:///project/* ]]; then
+    echo "project"
+  elif [[ "$input" == omnifocus:///tag/* ]]; then
+    echo "tag"
+  else
+    echo "task"
+  fi
+}
+```
+
+### `scripts/omni-actions/ofo-info.js` — add tag branch
+
+```js
+} else if (args.type === "tag") {
+  var tag = Tag.byIdentifier(args.id);
+  if (tag) {
+    var activeTasks = [];
+    tag.flattenedTasks.forEach(function(t) {
+      if (t.taskStatus === Task.Status.Completed || t.taskStatus === Task.Status.Dropped) return;
+      if (t.effectivelyCompleted || t.effectivelyDropped || t.completed) return;
+      activeTasks.push(t);
+    });
+    result = {
+      success: true,
+      tag: {
+        id: tag.id.primaryKey,
+        name: tag.name,
+        activeTaskCount: activeTasks.length,
+        tasks: activeTasks.slice(0, 50).map(function(t) {
+          return {
+            id: t.id.primaryKey,
+            name: t.name,
+            project: t.containingProject ? t.containingProject.name : null,
+            dueDate: t.dueDate ? t.dueDate.toISOString() : null,
+            flagged: t.flagged
+          };
+        })
+      }
+    };
+  } else {
+    result = { success: false, error: "Tag not found: " + args.id };
+  }
+}
+```
+
+**Notes:**
+- `Tag.byIdentifier()` follows the same Omni Automation API as `Task.byIdentifier` / `Project.byIdentifier` already used in the file
+- Triple-check filter pattern (from fix #98 / commit 6ee42b6): `taskStatus` + `effectivelyCompleted` + `effectivelyDropped` + `completed`
+- Cap task list at 50, consistent with `ofo search` limit
+- `tag.flattenedTasks` returns all tasks at any depth under the tag
+
+## Acceptance Criteria
+
+- [x] `ofo info omnifocus:///tag/<id>` returns `{ success: true, tag: { id, name, activeTaskCount, tasks: [...] } }`
+- [x] `ofo info omnifocus:///task/<id>` and `omnifocus:///project/<id>` continue to work unchanged
+- [x] Returned tasks include: id, name, project, dueDate, flagged
+- [x] Completed/dropped tasks excluded via triple-check pattern
+- [x] Returns `{ success: false, error: "Tag not found: ..." }` for invalid tag IDs
+
+## Context
+
+- **Issue**: #99
+- **Architecture**: Omni Automation script URL pattern — NOT JXA
+- **Filter pattern**: Triple-check introduced in #98 (commit 6ee42b6) — `taskStatus` + `effectivelyCompleted` + `effectivelyDropped` + `completed`
+- **Task cap**: 50 tasks, consistent with `ofo search`
+- **Bare ID routing**: Bare IDs (no URL scheme) continue to route as "task" — correct, since tag lookup via bare ID is not a use case
+
+## Validation
+
+```bash
+# Requires OmniFocus running with external script execution enabled
+ofo info omnifocus:///tag/fjyi9aLKyru    # AI Agent tag — should return tag data
+ofo info omnifocus:///task/<valid-id>    # Regression check
+ofo info omnifocus:///project/<valid-id> # Regression check
+ofo info omnifocus:///tag/nonexistent    # Should return error JSON
+```
+
+Run validators after editing `ofo-info.js`:
+```bash
+node scripts/validate-js-syntax.js scripts/omni-actions/ofo-info.js
+node scripts/validate-jxa-patterns.js scripts/omni-actions/ofo-info.js
+```

--- a/plugins/omnifocus-manager/.claude-plugin/plugin.json
+++ b/plugins/omnifocus-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omnifocus-manager",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "Query and manage OmniFocus tasks via Omni Automation script URLs (ofo CLI) and JXA, with GTD methodology coaching.",
   "author": {
     "name": "J. Greg Williams",

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/IMPROVEMENT_PLAN.md
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/IMPROVEMENT_PLAN.md
@@ -4,6 +4,7 @@
 
 | Version | Date | Issue | Summary | Conc | Comp | Spec | Disc | Overall |
 |---------|------|-------|---------|------|------|------|------|---------|
+| 7.4.0 | 2026-03-09 | [#99](https://github.com/totallyGreg/claude-mp/issues/99) | ofo info tag URL support: detect_type_from_url adds tag branch; ofo-info.js adds Tag.byIdentifier() lookup with triple-check active task filter, returns name/activeTaskCount/tasks (capped 50) | 83 | 90 | 90 | 100 | 91 |
 | 7.3.0 | 2026-03-09 | - | Update omnifocus-agent.md: add /ofo:plan, /ofo:work, /ofo:weekly-review routing entries; update weekly review example to use command; clean up omnifocus:// URL example | 83 | 90 | 90 | 100 | 91 |
 | 7.2.0 | 2026-03-09 | [#98](https://github.com/totallyGreg/claude-mp/issues/98) | Fix 8 remaining weak filters in taskQuery.js + ofo-search.js: upgrade completed()/dropped() to effectivelyCompleted/effectivelyDropped/completed triple-check pattern across listTasks, getTodayTasks, getDueSoon, getFlagged, searchTasks, searchTasksByTag, getWaitingForTasks, getRepeatingTasks | 83 | 90 | 90 | 100 | 91 |
 | 7.1.0 | 2026-03-09 | [#97](https://github.com/totallyGreg/claude-mp/issues/97) | Fix query accuracy: inbox filters completed/dropped; overdue uses Task.Status + completed() to exclude repeating instances (100→11 items); new ofo-perspective.js queries perspectives by name/ID; getStalledProjects uses flattenedTasks(); add "Prefer Perspectives" best practice | 83 | 90 | 90 | 100 | 91 |

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/SKILL.md
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/SKILL.md
@@ -5,7 +5,7 @@ description: |
 
   WORKFLOW: 1) CLASSIFY query vs plugin 2) SELECT format (solitary/solitary-fm/bundle/solitary-library) 3) COMPOSE from libraries 4) GENERATE via `node scripts/generate_plugin.js` - NEVER Write/Edit tools 5) VALIDATE via `bash scripts/validate-plugin.sh` 6) TEST in OmniFocus.
 metadata:
-  version: 7.3.0
+  version: 7.4.0
   author: totally-tools
   license: MIT
 compatibility:
@@ -206,4 +206,4 @@ See `references/troubleshooting.md` for permission issues, common errors, and de
 
 ---
 
-**Current version:** 7.2.0 — See IMPROVEMENT_PLAN.md for version history.
+**Current version:** 7.4.0 — See IMPROVEMENT_PLAN.md for version history.

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/scripts/ofo
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/scripts/ofo
@@ -46,6 +46,8 @@ detect_type_from_url() {
   local input="$1"
   if [[ "$input" == omnifocus:///project/* ]]; then
     echo "project"
+  elif [[ "$input" == omnifocus:///tag/* ]]; then
+    echo "tag"
   else
     echo "task"
   fi

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/scripts/omni-actions/ofo-info.js
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/scripts/omni-actions/ofo-info.js
@@ -24,6 +24,35 @@ if (args.type === "project") {
   } else {
     result = { success: false, error: "Project not found: " + args.id };
   }
+} else if (args.type === "tag") {
+  var tag = Tag.byIdentifier(args.id);
+  if (tag) {
+    var activeTasks = [];
+    tag.flattenedTasks.forEach(function(t) {
+      if (t.taskStatus === Task.Status.Completed || t.taskStatus === Task.Status.Dropped) return;
+      if (t.effectivelyCompleted || t.effectivelyDropped || t.completed) return;
+      activeTasks.push(t);
+    });
+    result = {
+      success: true,
+      tag: {
+        id: tag.id.primaryKey,
+        name: tag.name,
+        activeTaskCount: activeTasks.length,
+        tasks: activeTasks.slice(0, 50).map(function(t) {
+          return {
+            id: t.id.primaryKey,
+            name: t.name,
+            project: t.containingProject ? t.containingProject.name : null,
+            dueDate: t.dueDate ? t.dueDate.toISOString() : null,
+            flagged: t.flagged
+          };
+        })
+      }
+    };
+  } else {
+    result = { success: false, error: "Tag not found: " + args.id };
+  }
 } else {
   var t = Task.byIdentifier(args.id);
   if (t) {


### PR DESCRIPTION
## Summary

- `ofo info omnifocus:///tag/<id>` previously failed with "Task not found" because `detect_type_from_url` defaulted to `"task"` for any non-project URL
- Added `tag` detection branch in `detect_type_from_url` in `scripts/ofo`
- Added `Tag.byIdentifier()` lookup in `ofo-info.js` with the triple-check active task filter (from #98), returning tag name, active task count, and task list (capped at 50)

## Testing

- Bash syntax check: `bash -n scripts/ofo` ✅
- JS syntax check: `node --check scripts/omni-actions/ofo-info.js` ✅
- `Tag.byIdentifier()` confirmed in `typescript/omnifocus.d.ts:317`
- Skillsmith eval: 91/100 (consistent with previous versions)
- Manual validation command: `ofo info omnifocus:///tag/fjyi9aLKyru`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: local CLI tool with no network/database side effects; failure surfaces immediately as JSON error response.

Closes #99

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)