### PR TITLE
feat(omnifocus-manager): perspective-configure and completed-today commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -84,7 +84,7 @@
       "name": "omnifocus-manager",
       "description": "Interface with OmniFocus to surface insights, create reusable automations and perspectives, and suggest workflow optimizations",
       "category": "productivity",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "author": {
         "name": "J. Greg Williams",
         "email": "283704+totallyGreg@users.noreply.github.com"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A comprehensive marketplace for Claude Code extensions, providing plugins with s
 | Plugin | Version | Description |
 |--------|---------|-------------|
 | **confluence-pages** | 1.1.0 | Create, update, move, and delete Confluence pages via REST API |
-| **omnifocus-manager** | 8.1.0 | Interface with OmniFocus to surface insights, create reusable automations and perspectives, and suggest workflow optimizations |
+| **omnifocus-manager** | 8.2.0 | Interface with OmniFocus to surface insights, create reusable automations and perspectives, and suggest workflow optimizations |
 | **pkm-plugin** | 1.7.1 | Personal Knowledge Management expert for Obsidian vaults with dual-skill architecture: vault-architect (create structures) and vault-curator (evolve content) |
 
 ### Security (1 plugin)

--- a/docs/plans/2026-03-20-001-feat-end-of-day-routine-redesign-plan.md
+++ b/docs/plans/2026-03-20-001-feat-end-of-day-routine-redesign-plan.md
@@ -1,0 +1,209 @@
+---
+title: "feat: Redesign end-of-day routine with automated daily log"
+type: feat
+status: completed
+date: 2026-03-20
+origin: 820 Brainstorms/2026-03-19-end-of-day-routine-redesign-requirements.md
+---
+
+# feat: Redesign End-of-Day Routine with Automated Daily Log
+
+## Overview
+
+Rebuild the broken OmniFocus "End of day Routine" into a lean, repeating shutdown procedure that produces a categorized daily completion log in Obsidian. The routine serves as both a mental cutoff ritual and an artifact generator — each step either verifies a "done" criterion or triggers automation.
+
+(see origin: `820 Brainstorms/2026-03-19-end-of-day-routine-redesign-requirements.md`)
+
+## Problem Statement / Motivation
+
+The current routine has 2 stuck tasks, no recurrence, a missing perspective, and no automation. The note's "done" criteria (inbox zero, no unaddressed due items, completed list to Obsidian, track questions/discontents) don't map to the actual tasks. The user captures questions (`Question❓`), discontents (`Discontent⁉️`), and decisions (`Decide😤`) in OmniFocus but has no system to log completions across these categories into Obsidian.
+
+## Proposed Solution
+
+### Phase 1: OmniFocus Project + Perspectives
+
+**1a. Restructure the routine project**
+
+Replace the current 6 tasks with a lean set that maps to the "done" criteria:
+
+| Task | "Done" criterion | Type |
+|------|-----------------|------|
+| Process inbox to zero | Nothing in inbox | Review |
+| Clear due/overdue items | No due items unaddressed | Review |
+| Review daily log | Verify completions look right | Review |
+| Generate daily log | Completed tasks → Obsidian | Automation trigger |
+
+The project should:
+- Be set to sequential (tasks appear one at a time)
+- Repeat daily (defer to end-of-work time, e.g., 5:00 PM)
+- Keep tags `Evening🕕`, `Routine🔁`
+- Update the note to remove references to the missing perspective and reflect the new structure
+
+**1b. Add `perspective-configure` action to ofo-core.ts**
+
+New action that modifies filter rules on an existing custom perspective. The Omni Automation API allows `Perspective.Custom.byName()` retrieval and setting `archivedFilterRules` + `archivedTopLevelFilterAggregation`, but has no constructor — perspectives must be created manually in OmniFocus Pro first.
+
+The action accepts:
+- `name` or `id` — perspective to configure
+- `rules` — array of filter rule objects (replaces existing rules)
+- `aggregation` — "all", "any", or "none" (optional, defaults to "all")
+
+This enables programmatic perspective setup after one-time manual creation.
+
+**1c. Add `ofo perspective-configure` CLI command**
+
+New command in `ofo-cli.ts` that calls the `perspective-configure` action. Accepts `--name`, `--rules` (JSON string), and `--aggregation` flags.
+
+**1d. Create Shutdown Procedure perspective**
+
+Manually create an empty "Shutdown Procedure" perspective in OmniFocus Pro, then configure via `ofo perspective-configure`:
+- Rules: inbox items (available), due/overdue items, flagged items
+- Aggregation: "any" (show tasks matching any rule)
+
+**1e. Configure existing Completed Today perspective**
+
+Existing perspective (`omnifocus:///perspective/a0hgqFyITwd`) already has correct base rules:
+```json
+[
+  {"actionAvailability": "completed"},
+  {"actionDateField": "completed", "actionDateIsToday": true}
+]
+```
+Aggregation: `"all"`. Needs `Routine🔁` tag exclusion added (tag ID: `kyjgspU3bkU`).
+
+Note: The Omni Automation filter rule schema uses tag IDs, not names. Tag exclusion may require nested rules with `"none"` aggregation — test during implementation. If the perspective API can't express tag exclusion in rules, the `completed-today` action handles filtering in code (which it already does).
+
+### Phase 2: Daily Log CLI Command
+
+**Design principle: Perspectives over scripts.** The existing "Completed Today" perspective is the query engine. No new `ofo-core.ts` action is needed — the CLI command queries the perspective and handles filtering/formatting.
+
+**2a. Add `ofo completed-today` CLI command**
+
+New command in `ofo-cli.ts` that:
+1. Calls the existing `ofo-perspective` action with `name: "Completed Today"`
+2. Filters out `Routine🔁` tagged tasks in the CLI layer
+3. Categorizes remaining tasks by tag membership:
+   - **Tasks completed** — no special capture tag
+   - **Questions answered** — tagged `Question❓`
+   - **Discontents resolved** — tagged `Discontent⁉️`
+   - **Decisions made** — tagged `Decide😤`
+4. Default output: categorized JSON
+5. With `--markdown` flag: formatted markdown suitable for piping to `obsidian-cli`
+
+**2b. Obsidian integration via existing tools**
+
+No standalone script needed. Use `obsidian-cli` and the `vault-curator` skill for all Obsidian interactions:
+```bash
+ofo completed-today --markdown | obsidian append "500 ♽ Cycles/520 🌄 Days/YYYY/YYYY-MM-DD.md"
+```
+
+### Phase 3: Wire It Together
+
+- Update the routine's "Generate daily log" task note with the CLI command
+- Test the full flow: process inbox → clear overdue → review completions → generate log → check Obsidian
+- Verify recurrence works (complete routine → defers to tomorrow)
+
+## Technical Approach
+
+### Key files to modify/create
+
+| File | Change |
+|------|--------|
+| `scripts/src/ofo-core.ts` | Add `ofoPerspectiveConfigure()` action + dispatch case |
+| `scripts/src/ofo-core-ambient.d.ts` | Add writable `archivedFilterRules` / `archivedTopLevelFilterAggregation` declarations |
+| `scripts/src/ofo-cli.ts` | Add `perspective-configure` and `completed-today` commands (completed-today queries existing perspective, no new core action) |
+| `scripts/build-plugin.sh` | No changes needed (builds from src/) |
+| OmniFocus project | Restructure via ofo CLI (update/create/complete tasks) |
+| OmniFocus perspectives | Create empty perspectives manually, configure rules via `ofo perspective-configure` |
+
+### Daily log markdown format
+
+```markdown
+## Completed Today
+
+### Tasks
+- Task name 1 (Project Name)
+- Task name 2 (Project Name)
+
+### Questions Answered
+- Question text (Project Name)
+
+### Discontents Resolved
+- Discontent text (Project Name)
+
+### Decisions Made
+- Decision text (Project Name)
+```
+
+Sections with zero items are omitted. If nothing was completed, output a simple "No completions logged today."
+
+### Querying completed tasks
+
+The OmniFocus Omni Automation API provides `completionDate` on tasks. The query:
+```
+flattenedTasks.filter(t =>
+  t.completed &&
+  t.completionDate >= todayStart &&
+  t.completionDate < todayEnd &&
+  !t.tags.some(tag => tag.name === 'Routine🔁')
+)
+```
+
+Categorization by checking tag membership: `Question❓`, `Discontent⁉️`, `Decide😤`.
+
+## Acceptance Criteria
+
+- [ ] OmniFocus routine project restructured with 4 tasks matching "done" criteria
+- [ ] Project repeats daily with defer to end-of-work time
+- [ ] `ofo perspective-configure` sets filter rules and aggregation on an existing perspective
+- [ ] Shutdown Procedure perspective configured with inbox + due/overdue + flagged rules
+- [ ] Completed Today perspective configured with completed-today rules minus Routine
+- [ ] `ofo completed-today` queries Completed Today perspective and returns categorized JSON (no new core action — perspective is the query engine)
+- [ ] `ofo completed-today --markdown` outputs formatted markdown suitable for piping to `obsidian-cli`
+- [ ] Routine🔁 tagged tasks excluded from the log
+- [ ] Questions, discontents, and decisions appear in their own sections
+- [ ] Empty sections are omitted from the output
+- [ ] Skillsmith evaluation >= 95 after SKILL.md updates
+
+## Dependencies & Risks
+
+**Dependencies:**
+- ofo CLI v2.0.0 (TypeScript plugin library — just shipped)
+- obsidian-cli for appending to daily notes
+- OmniFocus 4 with Omni Automation enabled
+- Tags `Question❓`, `Discontent⁉️`, `Decide😤`, `Routine🔁` exist in OmniFocus
+
+**Risks:**
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| `completionDate` not available in Omni Automation API | Low | High | Test with one task first; fall back to JXA if needed |
+| obsidian-cli `append` doesn't support targeted insertion | Medium | Low | Append to end of file is acceptable |
+| Perspective creation requires manual OmniFocus Pro step | Medium | Low | Only the empty perspective must be created manually; rules are set via `ofo perspective-configure` |
+| Filter rule object schema undocumented | Medium | Medium | Inspect existing perspective rules via `ofo perspective` to reverse-engineer the schema |
+
+## Scope Boundaries
+
+- **In scope:** Project restructure, `perspective-configure` action, 2 perspectives, `completed-today` action, CLI command, daily log script
+- **Out of scope:** Metrics/analytics (questions per week, discontents per month)
+- **Out of scope:** Auto-processing questions (FAQ, research agents)
+- **Out of scope:** Auto-delegating discontents to agents
+- **Out of scope:** OmniFocus plugin action with keyboard shortcut (stretch goal, defer)
+
+## Sources & References
+
+### Origin
+
+- **Origin document:** [820 Brainstorms/2026-03-19-end-of-day-routine-redesign-requirements.md] — Key decisions: lean routine over checklist, filter by tag not project, dual trigger (CLI + OmniFocus), append not overwrite
+
+### Internal References
+
+- ofo-core.ts: `plugins/omnifocus-manager/skills/omnifocus-manager/scripts/src/ofo-core.ts`
+- ofo-cli.ts: `plugins/omnifocus-manager/skills/omnifocus-manager/scripts/src/ofo-cli.ts`
+- CONTRIBUTING.md: `plugins/omnifocus-manager/CONTRIBUTING.md`
+- Omni Automation guide: `plugins/omnifocus-manager/skills/omnifocus-manager/references/omni_automation_guide.md`
+
+### Related Work
+
+- Issue #111: Automatic learning pipeline (this adds the first compound action: `completed-today`)
+- PR #112: TypeScript plugin library migration (foundation for this work)

--- a/plugins/omnifocus-manager/.claude-plugin/plugin.json
+++ b/plugins/omnifocus-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "omnifocus-manager",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Query and manage OmniFocus tasks via Omni Automation script URLs (ofo CLI) and JXA, with GTD methodology coaching.",
   "author": {
     "name": "J. Greg Williams",

--- a/plugins/omnifocus-manager/CONTRIBUTING.md
+++ b/plugins/omnifocus-manager/CONTRIBUTING.md
@@ -25,7 +25,7 @@ CLI polls pasteboard, outputs JSON to stdout
 ```
 
 **Source files** (TypeScript, in `scripts/src/`):
-- `ofo-core.ts` — All action handlers (info, complete, create, create-batch, update, search, list, tag, tags, perspective)
+- `ofo-core.ts` — All action handlers (info, complete, create, create-batch, update, search, list, tag, tags, perspective, perspective-configure)
 - `ofo-cli.ts` — Argument parsing, URL construction, pasteboard polling
 - `ofo-stub.js` — Stable script sent via URL (approved once, never changes)
 - `manifest.json` — Plugin bundle manifest

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/README.md
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/README.md
@@ -12,16 +12,16 @@ Query and manage OmniFocus tasks via Omni Automation script URLs (ofo CLI) and J
 
 ## Current Metrics
 
-*Last evaluated: 2026-03-19*
+*Last evaluated: 2026-03-20*
 
 | Metric | Score | Interpretation |
 |--------|-------|----------------|
-| Conciseness | 100/100 | Excellent |
+| Conciseness | 98/100 | Excellent |
 | Complexity | 90/100 | Good |
-| Spec Compliance | 90/100 | Good |
+| Spec Compliance | 100/100 | Excellent |
 | Progressive Disclosure | 100/100 | Excellent |
 | Description Quality | 100/100 | Excellent |
-| **Overall** | **95/100** | Good |
+| **Overall** | **97/100** | **Excellent** |
 
 Run `uv run scripts/evaluate_skill.py <path> --explain` for improvement suggestions.
 
@@ -29,6 +29,8 @@ Run `uv run scripts/evaluate_skill.py <path> --explain` for improvement suggesti
 
 | Version | Date | Issue | Summary | Conc | Comp | Spec | Disc | Desc | Overall |
 |---------|------|-------|---------|------|------|------|------|------|---------|
+| 8.2.0 | 2026-03-20 | — | Add perspective-configure action, completed-today CLI command (perspectives-over-scripts pattern); fix license frontmatter placement | 98 | 90 | 100 | 100 | 100 | 97 |
+| 8.1.0 | 2026-03-19 | [#116](https://github.com/totallyGreg/claude-mp/pull/116) | ofo CLI: tag command with capture shortcuts, tags hierarchy, create-batch; fix flattenedTags global | 100 | 90 | 90 | 100 | 100 | 95 |
 | 8.0.0 | 2026-03-19 | [#111](https://github.com/totallyGreg/claude-mp/issues/111) | Migrate ofo CLI to TypeScript plugin library: ofo-core.ts (7 actions), ofo-cli.ts (arg parsing), installed .omnifocusjs bundle, stable stub script, zero auth prompts after checkbox; CONTRIBUTING.md rewrite | 100 | 90 | 90 | 100 | 100 | 95 |
 | 7.5.0 | 2026-03-19 | [#98](https://github.com/totallyGreg/claude-mp/issues/98), [#101](https://github.com/totallyGreg/claude-mp/issues/101) | Tag query perf: flattenedTasks→tag.tasks() (563x speedup), whose() crash fix; consolidate 7 action scripts into ofo-dispatcher.js, remove ofo setup; add /ofo-tagged command; CONTRIBUTING.md; inbox filter fix | 100 | 90 | 90 | 100 | 100 | 95 |
 | 7.4.3 | 2026-03-15 | — | ofo-work: use `ofo complete` (Omni Automation) not `manage_omnifocus.js complete` (JXA) — fixes -10003 permission error | 83 | 90 | 90 | 100 | - | 91 |

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/SKILL.md
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/SKILL.md
@@ -4,10 +4,10 @@ description: |
   This skill should be used when working with OmniFocus data, running GTD diagnostics, configuring perspectives, or generating OmniFocus plugins. Triggers when user asks "show tasks", "overdue items", "check inbox", "stalled projects", "waiting for list", "someday maybe", "GTD health check", "create a plugin", "analyze OmniFocus", "AI Agent tasks", "publish plan to OmniFocus", "set up perspectives", "perspective inventory", "configure perspective", or "missing perspectives". Also triggers when the user pastes an `omnifocus://` URL — parse the entity type and ID from the URL, then use `/ofo:info <url>` to look it up directly. For pure GTD methodology coaching, use the gtd-coach skill instead.
 
   WORKFLOW: 1) CLASSIFY query vs plugin 2) SELECT format (solitary/solitary-fm/bundle/solitary-library) 3) COMPOSE from libraries 4) GENERATE via `node scripts/generate_plugin.js` - NEVER Write/Edit tools 5) VALIDATE via `bash scripts/validate-plugin.sh` 6) TEST in OmniFocus.
+license: MIT
 metadata:
-  version: 8.1.0
+  version: 8.2.0
   author: totally-tools
-  license: MIT
 compatibility:
   platforms: [macos]
   requires:
@@ -95,6 +95,9 @@ scripts/ofo list flagged                     # All flagged active tasks
 scripts/ofo tag <id> --add "Tag" --remove "Other"  # Granular tag manipulation
 scripts/ofo tag <id> --capture question      # Capture pipeline shortcut
 scripts/ofo tags                             # Full tag hierarchy as JSON
+scripts/ofo perspective-configure --name "View" --rules '[...]'  # Set perspective filter rules
+scripts/ofo completed-today                  # Today's completions categorized by tag (JSON)
+scripts/ofo completed-today --markdown       # Same, formatted for Obsidian append
 echo "Buy milk" | scripts/ofo create         # Stdin: first line = name
 echo '{"name":"X","project":"P"}' | scripts/ofo create  # Stdin: JSON
 ```
@@ -122,13 +125,22 @@ osascript -l JavaScript scripts/gtd-queries.js --action folder-structure
 
 ### 2. Manage Perspectives
 
+**Principle: Perspectives over scripts.** Prefer codifying perspectives as the query engine over creating new plugin actions. Use `ofo perspective` to read and `ofo perspective-configure` to write filter rules on existing perspectives. The CLI handles post-processing (filtering, categorization, formatting).
+
 ```bash
+# ofo CLI (preferred)
+scripts/ofo perspective "Completed Today"           # Query perspective contents
+scripts/ofo perspective-configure --name "Completed Today" --rules '[{"actionAvailability":"completed"},{"actionDateField":"completed","actionDateIsToday":true}]'
+scripts/ofo perspective-configure --name "My View" --aggregation any
+
+# JXA (legacy, for perspective inventory)
 osascript -l JavaScript scripts/gtd-queries.js --action perspective-inventory
 osascript -l JavaScript scripts/perspective-config.js --action show --name "Next Actions"
 osascript -l JavaScript scripts/perspective-config.js --action apply-template --name "Next Actions" --template next-actions
-osascript -l JavaScript scripts/perspective-config.js --action apply --name "My View" --rules '[{"actionAvailability":"available"}]'
 osascript -l JavaScript scripts/perspective-config.js --action list-templates
 ```
+
+Note: Perspectives must be created manually in OmniFocus Pro — the API has no constructor. Filter rules use tag IDs, not names.
 
 See `references/perspective_templates.md` for 8 canonical GTD perspective JSON configs.
 See `references/perspective_creation.md` for the guided configuration workflow.

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/scripts/build/ofo-cli.js
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/scripts/build/ofo-cli.js
@@ -334,6 +334,175 @@ function cmdTag(args) {
     }
     runAction('ofo-tag', { id, add: addTags, remove: removeTags });
 }
+function cmdPerspectiveConfigure(args) {
+    let name = '', id = '', rules = '', aggregation = '';
+    let i = 0;
+    while (i < args.length) {
+        switch (args[i]) {
+            case '--name':
+                name = args[++i] || '';
+                break;
+            case '--id':
+                id = args[++i] || '';
+                break;
+            case '--rules':
+                rules = args[++i] || '';
+                break;
+            case '--aggregation':
+                aggregation = args[++i] || '';
+                break;
+            default: die('Unknown option: ' + args[i]);
+        }
+        i++;
+    }
+    if (!name && !id)
+        die('Usage: ofo perspective-configure --name "Name" --rules \'[...]\'');
+    if (!rules && !aggregation)
+        die('At least one of --rules or --aggregation is required');
+    const argObj = {};
+    if (name)
+        argObj.name = name;
+    if (id)
+        argObj.id = id;
+    if (rules) {
+        try {
+            argObj.rules = JSON.parse(rules);
+        }
+        catch {
+            die('Invalid JSON for --rules: ' + rules);
+        }
+    }
+    if (aggregation)
+        argObj.aggregation = aggregation;
+    runAction('ofo-perspective-configure', argObj);
+}
+function cmdCompletedToday(args) {
+    let markdown = false;
+    for (const arg of args) {
+        if (arg === '--markdown')
+            markdown = true;
+        else
+            die('Unknown option: ' + arg);
+    }
+    // Use a synchronous approach: call runAction which writes to stdout,
+    // but we need to intercept the result for post-processing.
+    // Override stdout to capture the perspective result.
+    const perspectiveName = 'Completed Today';
+    const stubPath = join(__dirname, 'ofo-stub.js');
+    let stub;
+    try {
+        stub = readFileSync(stubPath, 'utf-8');
+    }
+    catch {
+        die('Stub script not found: ' + stubPath);
+    }
+    const argJson = JSON.stringify({ action: 'ofo-perspective', name: perspectiveName });
+    const encodedScript = urlEncode(stub);
+    const encodedArg = urlEncode(argJson);
+    pbcopy('__ofo_pending__');
+    execSync(`open "omnifocus://localhost/omnijs-run?script=${encodedScript}&arg=${encodedArg}"`, {
+        stdio: 'ignore'
+    });
+    const maxAttempts = 50;
+    let rawResult = '';
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        execSync('sleep 0.2');
+        const result = pbpaste();
+        if (result !== '__ofo_pending__') {
+            rawResult = result;
+            break;
+        }
+    }
+    if (!rawResult) {
+        process.stdout.write('{"success":false,"error":"Timeout waiting for OmniFocus response"}');
+        process.exit(1);
+    }
+    let data;
+    try {
+        data = JSON.parse(rawResult);
+    }
+    catch {
+        process.stdout.write(rawResult);
+        return;
+    }
+    if (!data.success) {
+        process.stdout.write(rawResult);
+        return;
+    }
+    const items = data.items || [];
+    // Filter out Routine🔁 tagged tasks
+    const filtered = items.filter((t) => !t.tags || !t.tags.includes('Routine🔁'));
+    // Categorize by capture tags
+    const questions = [];
+    const discontents = [];
+    const decisions = [];
+    const tasks = [];
+    for (const t of filtered) {
+        const tagList = t.tags || [];
+        if (tagList.includes('Question❓'))
+            questions.push(t);
+        else if (tagList.includes('Discontent⁉️'))
+            discontents.push(t);
+        else if (tagList.includes('Decide😤'))
+            decisions.push(t);
+        else
+            tasks.push(t);
+    }
+    if (markdown) {
+        const lines = [];
+        if (filtered.length === 0) {
+            lines.push('No completions logged today.');
+        }
+        else {
+            lines.push('## Completed Today');
+            lines.push('');
+            if (tasks.length > 0) {
+                lines.push('### Tasks');
+                for (const t of tasks) {
+                    const proj = t.project ? ` (${t.project})` : '';
+                    lines.push(`- ${t.name}${proj}`);
+                }
+                lines.push('');
+            }
+            if (questions.length > 0) {
+                lines.push('### Questions Answered');
+                for (const t of questions) {
+                    const proj = t.project ? ` (${t.project})` : '';
+                    lines.push(`- ${t.name}${proj}`);
+                }
+                lines.push('');
+            }
+            if (discontents.length > 0) {
+                lines.push('### Discontents Resolved');
+                for (const t of discontents) {
+                    const proj = t.project ? ` (${t.project})` : '';
+                    lines.push(`- ${t.name}${proj}`);
+                }
+                lines.push('');
+            }
+            if (decisions.length > 0) {
+                lines.push('### Decisions Made');
+                for (const t of decisions) {
+                    const proj = t.project ? ` (${t.project})` : '';
+                    lines.push(`- ${t.name}${proj}`);
+                }
+                lines.push('');
+            }
+        }
+        process.stdout.write(lines.join('\n'));
+    }
+    else {
+        process.stdout.write(JSON.stringify({
+            success: true,
+            date: new Date().toISOString().slice(0, 10),
+            totalCompleted: filtered.length,
+            tasks,
+            questions,
+            discontents,
+            decisions
+        }));
+    }
+}
 function cmdTags() {
     runAction('ofo-tags', {});
 }
@@ -352,6 +521,8 @@ Commands:
   tag <id|url> [options]            Add/remove tags on a task
   tags                              List all tags as JSON hierarchy
   perspective <name> [--id ID]      Query a custom perspective
+  perspective-configure [options]   Set filter rules on a perspective
+  completed-today [--markdown]      Today's completions categorized by tag
   help                              Show this help
 
 Filters for 'list':
@@ -390,6 +561,18 @@ Stdin support (create):
   echo '{"name":"X"}' | ofo create           JSON object with task fields
   echo '[{"name":"A"},...]' | ofo create     JSON array for batch creation
   Flags (--project, --tags) merge with stdin; --name overrides stdin name
+
+Perspective-configure options:
+  --name "Name"             Perspective to configure (by name)
+  --id "ID"                 Perspective to configure (by ID)
+  --rules '[...]'           JSON array of filter rule objects
+  --aggregation all|any|none  Filter aggregation mode
+
+Completed-today options:
+  --markdown                Output as markdown (default: JSON)
+  Queries "Completed Today" perspective, excludes Routine🔁,
+  categorizes by Question❓, Discontent⁉️, Decide😤 tags.
+  Pipe to obsidian-cli: ofo completed-today --markdown | obsidian append "path"
 
 URL handling:
   All commands accept omnifocus:// URLs:
@@ -440,6 +623,12 @@ switch (command) {
         break;
     case 'perspective':
         cmdPerspective(commandArgs);
+        break;
+    case 'perspective-configure':
+        cmdPerspectiveConfigure(commandArgs);
+        break;
+    case 'completed-today':
+        cmdCompletedToday(commandArgs);
         break;
     case 'help':
     case '--help':

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/scripts/package.json
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/scripts/package.json
@@ -9,7 +9,7 @@
     "build:generator": "tsc",
     "build:plugin": "bash build-plugin.sh",
     "build:cli": "tsc --project src/tsconfig.cli.json && cp src/ofo-stub.js build/ofo-stub.js",
-    "deploy": "cp -r build/ofo-core.omnifocusjs \"$HOME/Library/Containers/com.omnigroup.OmniFocus4/Data/Library/Application Support/Plug-Ins/ofo-core.omnifocusjs\"",
+    "deploy": "rm -rf \"$HOME/Library/Containers/com.omnigroup.OmniFocus4/Data/Library/Application Support/Plug-Ins/ofo-core.omnifocusjs\" && cp -r build/ofo-core.omnifocusjs \"$HOME/Library/Containers/com.omnigroup.OmniFocus4/Data/Library/Application Support/Plug-Ins/ofo-core.omnifocusjs\"",
     "watch": "tsc --watch",
     "generate": "node generate_plugin.js"
   },

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/scripts/src/ofo-cli.ts
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/scripts/src/ofo-cli.ts
@@ -314,6 +314,178 @@ function cmdTag(args: string[]): void {
   runAction('ofo-tag', { id, add: addTags, remove: removeTags });
 }
 
+function cmdPerspectiveConfigure(args: string[]): void {
+  let name = '', id = '', rules = '', aggregation = '';
+
+  let i = 0;
+  while (i < args.length) {
+    switch (args[i]) {
+      case '--name': name = args[++i] || ''; break;
+      case '--id':   id = args[++i] || ''; break;
+      case '--rules': rules = args[++i] || ''; break;
+      case '--aggregation': aggregation = args[++i] || ''; break;
+      default: die('Unknown option: ' + args[i]);
+    }
+    i++;
+  }
+
+  if (!name && !id) die('Usage: ofo perspective-configure --name "Name" --rules \'[...]\'');
+  if (!rules && !aggregation) die('At least one of --rules or --aggregation is required');
+
+  const argObj: Record<string, unknown> = {};
+  if (name) argObj.name = name;
+  if (id) argObj.id = id;
+  if (rules) {
+    try {
+      argObj.rules = JSON.parse(rules);
+    } catch {
+      die('Invalid JSON for --rules: ' + rules);
+    }
+  }
+  if (aggregation) argObj.aggregation = aggregation;
+
+  runAction('ofo-perspective-configure', argObj);
+}
+
+function cmdCompletedToday(args: string[]): void {
+  let markdown = false;
+  for (const arg of args) {
+    if (arg === '--markdown') markdown = true;
+    else die('Unknown option: ' + arg);
+  }
+
+  // Use a synchronous approach: call runAction which writes to stdout,
+  // but we need to intercept the result for post-processing.
+  // Override stdout to capture the perspective result.
+  const perspectiveName = 'Completed Today';
+  const stubPath = join(__dirname, 'ofo-stub.js');
+  let stub: string;
+  try {
+    stub = readFileSync(stubPath, 'utf-8');
+  } catch {
+    die('Stub script not found: ' + stubPath);
+  }
+
+  const argJson = JSON.stringify({ action: 'ofo-perspective', name: perspectiveName });
+  const encodedScript = urlEncode(stub);
+  const encodedArg = urlEncode(argJson);
+
+  pbcopy('__ofo_pending__');
+
+  execSync(`open "omnifocus://localhost/omnijs-run?script=${encodedScript}&arg=${encodedArg}"`, {
+    stdio: 'ignore'
+  });
+
+  const maxAttempts = 50;
+  let rawResult = '';
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    execSync('sleep 0.2');
+    const result = pbpaste();
+    if (result !== '__ofo_pending__') {
+      rawResult = result;
+      break;
+    }
+  }
+
+  if (!rawResult) {
+    process.stdout.write('{"success":false,"error":"Timeout waiting for OmniFocus response"}');
+    process.exit(1);
+  }
+
+  let data: any;
+  try {
+    data = JSON.parse(rawResult);
+  } catch {
+    process.stdout.write(rawResult);
+    return;
+  }
+
+  if (!data.success) {
+    process.stdout.write(rawResult);
+    return;
+  }
+
+  const items: any[] = data.items || [];
+
+  // Filter out Routine🔁 tagged tasks
+  const filtered = items.filter((t: any) =>
+    !t.tags || !t.tags.includes('Routine🔁')
+  );
+
+  // Categorize by capture tags
+  const questions: any[] = [];
+  const discontents: any[] = [];
+  const decisions: any[] = [];
+  const tasks: any[] = [];
+
+  for (const t of filtered) {
+    const tagList: string[] = t.tags || [];
+    if (tagList.includes('Question❓')) questions.push(t);
+    else if (tagList.includes('Discontent⁉️')) discontents.push(t);
+    else if (tagList.includes('Decide😤')) decisions.push(t);
+    else tasks.push(t);
+  }
+
+  if (markdown) {
+    const lines: string[] = [];
+
+    if (filtered.length === 0) {
+      lines.push('No completions logged today.');
+    } else {
+      lines.push('## Completed Today');
+      lines.push('');
+
+      if (tasks.length > 0) {
+        lines.push('### Tasks');
+        for (const t of tasks) {
+          const proj = t.project ? ` (${t.project})` : '';
+          lines.push(`- ${t.name}${proj}`);
+        }
+        lines.push('');
+      }
+
+      if (questions.length > 0) {
+        lines.push('### Questions Answered');
+        for (const t of questions) {
+          const proj = t.project ? ` (${t.project})` : '';
+          lines.push(`- ${t.name}${proj}`);
+        }
+        lines.push('');
+      }
+
+      if (discontents.length > 0) {
+        lines.push('### Discontents Resolved');
+        for (const t of discontents) {
+          const proj = t.project ? ` (${t.project})` : '';
+          lines.push(`- ${t.name}${proj}`);
+        }
+        lines.push('');
+      }
+
+      if (decisions.length > 0) {
+        lines.push('### Decisions Made');
+        for (const t of decisions) {
+          const proj = t.project ? ` (${t.project})` : '';
+          lines.push(`- ${t.name}${proj}`);
+        }
+        lines.push('');
+      }
+    }
+
+    process.stdout.write(lines.join('\n'));
+  } else {
+    process.stdout.write(JSON.stringify({
+      success: true,
+      date: new Date().toISOString().slice(0, 10),
+      totalCompleted: filtered.length,
+      tasks,
+      questions,
+      discontents,
+      decisions
+    }));
+  }
+}
+
 function cmdTags(): void {
   runAction('ofo-tags', {});
 }
@@ -333,6 +505,8 @@ Commands:
   tag <id|url> [options]            Add/remove tags on a task
   tags                              List all tags as JSON hierarchy
   perspective <name> [--id ID]      Query a custom perspective
+  perspective-configure [options]   Set filter rules on a perspective
+  completed-today [--markdown]      Today's completions categorized by tag
   help                              Show this help
 
 Filters for 'list':
@@ -372,6 +546,18 @@ Stdin support (create):
   echo '[{"name":"A"},...]' | ofo create     JSON array for batch creation
   Flags (--project, --tags) merge with stdin; --name overrides stdin name
 
+Perspective-configure options:
+  --name "Name"             Perspective to configure (by name)
+  --id "ID"                 Perspective to configure (by ID)
+  --rules '[...]'           JSON array of filter rule objects
+  --aggregation all|any|none  Filter aggregation mode
+
+Completed-today options:
+  --markdown                Output as markdown (default: JSON)
+  Queries "Completed Today" perspective, excludes Routine🔁,
+  categorizes by Question❓, Discontent⁉️, Decide😤 tags.
+  Pipe to obsidian-cli: ofo completed-today --markdown | obsidian append "path"
+
 URL handling:
   All commands accept omnifocus:// URLs:
     ofo info omnifocus:///task/abc123
@@ -406,9 +592,11 @@ switch (command) {
   case 'update':      cmdUpdate(commandArgs); break;
   case 'search':      cmdSearch(commandArgs); break;
   case 'list':        cmdList(commandArgs); break;
-  case 'tag':         cmdTag(commandArgs); break;
-  case 'tags':        cmdTags(); break;
-  case 'perspective': cmdPerspective(commandArgs); break;
+  case 'tag':                   cmdTag(commandArgs); break;
+  case 'tags':                  cmdTags(); break;
+  case 'perspective':           cmdPerspective(commandArgs); break;
+  case 'perspective-configure': cmdPerspectiveConfigure(commandArgs); break;
+  case 'completed-today':       cmdCompletedToday(commandArgs); break;
   case 'help':
   case '--help':
   case '-h':          cmdHelp(); break;

--- a/plugins/omnifocus-manager/skills/omnifocus-manager/scripts/src/ofo-core.ts
+++ b/plugins/omnifocus-manager/skills/omnifocus-manager/scripts/src/ofo-core.ts
@@ -308,6 +308,37 @@ function ofoPerspective(args: OfoArgs): OfoResult {
   };
 }
 
+// === PERSPECTIVE CONFIGURE ===
+
+function ofoPerspectiveConfigure(args: OfoArgs): OfoResult {
+  const name = (args.name as string) || null;
+  const id = (args.id as string) || null;
+
+  let target: Perspective.Custom | null = null;
+  if (id) target = Perspective.Custom.byIdentifier(id);
+  else if (name) target = Perspective.Custom.byName(name);
+
+  if (!target) return { success: false, error: 'Perspective not found: ' + (name || id) };
+
+  const rules = args.rules as object[] | undefined;
+  const aggregation = args.aggregation as string | undefined;
+
+  if (!rules && !aggregation) {
+    return { success: false, error: 'At least one of rules or aggregation is required' };
+  }
+
+  if (rules) target.archivedFilterRules = rules;
+  if (aggregation) target.archivedTopLevelFilterAggregation = aggregation;
+
+  return {
+    success: true,
+    perspective: target.name,
+    perspectiveId: target.id.primaryKey,
+    filterRules: target.archivedFilterRules,
+    aggregation: target.archivedTopLevelFilterAggregation
+  };
+}
+
 // === TAG ===
 
 function ofoTag(args: OfoArgs): OfoResult {
@@ -401,6 +432,7 @@ function dispatch(args: OfoArgs): OfoResult {
     case 'ofo-search':      return ofoSearch(args);
     case 'ofo-list':        return ofoList(args);
     case 'ofo-perspective': return ofoPerspective(args);
+    case 'ofo-perspective-configure': return ofoPerspectiveConfigure(args);
     case 'ofo-tag':         return ofoTag(args);
     case 'ofo-tags':        return ofoTags(args);
     case 'ofo-create-batch': return ofoCreateBatch(args);


### PR DESCRIPTION
## Summary

- Add `perspective-configure` action to ofo-core.ts for programmatic filter rule management on existing OmniFocus perspectives
- Add `completed-today` CLI command that queries the "Completed Today" perspective, filters out Routine🔁 tasks, and categorizes completions by capture tags (Question❓, Discontent⁉️, Decide😤)
- Supports `--markdown` output for piping to obsidian-cli
- Fix deploy script (rm before cp) to prevent stale plugin bundles
- Fix `license` frontmatter placement per agent skill spec

### Design Principle: Perspectives Over Scripts

No new plugin-side query action was needed. The existing "Completed Today" perspective serves as the query engine — the CLI command handles post-processing (filtering, categorization, formatting) only. This avoids duplicating query logic and keeps OmniFocus perspectives as the single source of truth.

### Usage

```bash
ofo completed-today                  # Categorized JSON
ofo completed-today --markdown       # Markdown for Obsidian
ofo completed-today --markdown | obsidian append "500 ♽ Cycles/520 🌄 Days/2026/2026-03-20.md"
ofo perspective-configure --name "Completed Today" --rules '[{"actionAvailability":"completed"}]'
```

## Testing

- [x] `ofo completed-today` returns categorized JSON (85 tasks, Routine excluded)
- [x] `ofo completed-today --markdown` outputs formatted markdown with sections
- [x] `ofo perspective-configure` sets filter rules on existing perspective
- [x] `npm run build` compiles without errors
- [x] Plugin deployed and tested E2E in OmniFocus
- [x] Skillsmith evaluation: 97/100

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: changes are local CLI tools with no production/runtime impact.

---

[![Compound Engineering v2.46.0](https://img.shields.io/badge/Compound_Engineering-v2.46.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)