### PR TITLE
feat(archivist): add linking discipline, graph traversal, and schema …

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -58,7 +58,7 @@
       "name": "archivist",
       "description": "Personal Knowledge Management expert for Obsidian vaults with dual-skill architecture: vault-architect (create structures) and vault-curator (evolve content)",
       "category": "productivity",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "author": {
         "name": "J. Greg Williams",
         "email": "283704+totallyGreg@users.noreply.github.com"

--- a/plugins/archivist/.claude-plugin/plugin.json
+++ b/plugins/archivist/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "archivist",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Personal Knowledge Management expert for Obsidian vaults with autonomous orchestration",
   "author": {
     "name": "J. Greg Williams",

--- a/plugins/archivist/README.md
+++ b/plugins/archivist/README.md
@@ -41,16 +41,17 @@ MIT
 
 ### Current Metrics
 
-**Score: 94/100** (Good) — 2026-03-31
+**Score: 93/100** (Good) — 2026-04-11
 
 | Concs | Complx | Spec | Progr | Descr |
 |-------|--------|------|-------|-------|
-| 80 | 90 | 100 | 100 | 100 |
+| 79 | 90 | 100 | 100 | 100 |
 
 ### Version History
 
 | Version | Date | Issue | Summary | Concs | Complx | Spec | Progr | Descr | Score |
 |---------|------|-------|---------|-------|--------|------|-------|-------|-------|
+| 1.9.0 | 2026-04-11 | - | Add linking discipline to Design Principles: link aggressively, no backticked vault entities; schema authority: .base default view is canonical, fileClass mirrors it; pointer to linking-discipline.md | 79 | 90 | 100 | 100 | 100 | 93 |
 | 1.8.0 | 2026-03-31 | - | Add Vault Profiling workflow, Write Boundaries section, replace hardcoded vault path with ${VAULT_PATH} | 80 | 90 | 100 | 100 | 100 | 94 |
 | 1.7.0 | 2026-03-28 | - | Add Linter plugin config read to Vault Discovery; read .obsidian/plugins/obsidian-linter/data.json before writing notes | 98 | 100 | 100 | 100 | 100 | 99 |
 | 1.6.0 | 2026-03-28 | - | Add CLI delegation block to Vault Discovery naming obsidian-skills as source; document path= vs file= distinction and folder-note resolution | 98 | 100 | 100 | 100 | 100 | 99 |
@@ -68,16 +69,17 @@ MIT
 
 ### Current Metrics
 
-**Score: 99/100** (Excellent) — 2026-04-01
+**Score: 96/100** (Excellent) — 2026-04-11
 
 | Concs | Complx | Spec | Progr | Descr |
 |-------|--------|------|-------|-------|
-| 98 | 100 | 100 | 100 | 100 |
+| 83 | 100 | 100 | 100 | 100 |
 
 ### Version History
 
 | Version | Date | Issue | Summary | Concs | Complx | Spec | Progr | Descr | Score |
 |---------|------|-------|---------|-------|--------|------|-------|-------|-------|
+| 1.11.0 | 2026-04-11 | - | Add Wikilinks over backticks rule to Write Quality Gate; graph traversal commands to cli-patterns.md; create linking-discipline.md reference (decision table, schema authority, graph CLI commands) | 83 | 100 | 100 | 100 | 100 | 96 |
 | 1.10.0 | 2026-04-01 | - | Demote Write Boundaries to H3; add Base Files and File Relocation rules to cli-patterns.md; offload verbose docs to references/ | 98 | 100 | 100 | 100 | 100 | 99 |
 | 1.9.4 | 2026-03-31 | - | Add Write Boundaries section for vault-aware permission zones | 80 | 90 | 100 | 100 | 100 | 94 |
 | 1.9.3 | 2026-03-28 | - | Add Vault Write Quality Gate: frontmatter must start on line 1, Linter compliance check, bulk validation pointer | 98 | 90 | 100 | 100 | 100 | 97 |

--- a/plugins/archivist/agents/archivist.md
+++ b/plugins/archivist/agents/archivist.md
@@ -95,7 +95,19 @@ At the start of every session, run these steps in order before doing anything el
 
 ## Obsidian CLI Usage
 
-See `${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/references/cli-patterns.md` for known bugs, safety rules, and when to fall back to file tools. The obsidian-skills marketplace (`obsidian-cli` skill) is the canonical command reference.
+See `${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/references/cli-patterns.md` for known bugs, safety rules, graph traversal commands, and when to fall back to file tools. The obsidian-skills marketplace (`obsidian-cli` skill) is the canonical command reference.
+
+## Linking Discipline
+
+**Default to `[[Target]]` for any vault entity reference** when authoring or revising vault content. This includes fileClass notes, `.base` files, templates, folders, canvases, and other notes.
+
+Use backticks only for: shell commands, CLI argument paths, YAML property keys, and code identifiers.
+
+**Why:** Every `[[Target]]` creates a graph edge — visible in Obsidian's Backlinks pane, traversable via `obsidian backlinks`/`links`, and rename-safe via `obsidian move`. Backtick references are invisible to the graph and become dead references after renames.
+
+**Schema authority:** The `.base` file's default view is canonical for a type's properties and types. The metadata-menu fileClass note mirrors it — update the fileClass *after* changing the Base, never before. When linking to a type, link the Base first, fileClass second.
+
+For the full decision table, anti-patterns, and graph CLI usage, see `${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/references/linking-discipline.md`.
 
 ## Domain Knowledge
 
@@ -110,6 +122,7 @@ Both skill files are loaded at initialization (see above). Use them as authorita
 **vault-curator** (loaded from SKILL.md) handles: scope selection, metadata workflows (property suggestions, schema drift), consolidation (duplicates, merge, link redirect), discovery (related notes, progressive views, auto-linking), visualization (canvas maps), meeting extraction, vault migration. For deep reference, Read from `${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/references/`:
 - `migration-strategies.md` — Migration patterns
 - `consolidation-protocol.md` — Merge semantics, conflict resolution, rollback
+- `linking-discipline.md` — Linking rules, decision table, schema authority, graph CLI commands
 
 ## Workflow Orchestration
 

--- a/plugins/archivist/skills/vault-architect/SKILL.md
+++ b/plugins/archivist/skills/vault-architect/SKILL.md
@@ -14,7 +14,7 @@ description: >
 license: MIT
 compatibility: Requires python3 and uv for script execution
 metadata:
-  version: "1.8.0"
+  version: "1.9.0"
   plugin: "archivist"
   stage: "3"
 ---
@@ -319,9 +319,11 @@ Before writing to any path in the vault, check whether it falls within your allo
 
 ## Design Principles
 
-**Do:** Start simple — add complexity only when needed. Use frontmatter over folders for dynamic structure. Test templates with sample notes. Leverage aliases for automatic aggregation. Embed Bases views to bring organization to notes. Document conventions in a vault System Guide. Migrate patterns incrementally.
+**Do:** Start simple — add complexity only when needed. Use frontmatter over folders for dynamic structure. Test templates with sample notes. Leverage aliases for automatic aggregation. Embed Bases views to bring organization to notes. Document conventions in a vault System Guide. Migrate patterns incrementally. **Link aggressively** — every reference to another vault entity uses `[[Target]]`, powering backlinks, graph discovery, and rename-safe updates. The `.base` file's default view is canonical for a type's schema; the fileClass note mirrors it.
 
-**Avoid:** Manual filing (users forget folder structures). Rigid folder hierarchies. Duplicating information (use queries and embeds). Hardcoded paths (breaks on job change). Inline Dataview metadata (Bases requires frontmatter). Designing notes in isolation without considering relationships.
+**Avoid:** Manual filing (users forget folder structures). Rigid folder hierarchies. Duplicating information (use queries and embeds). Hardcoded paths (breaks on job change). Inline Dataview metadata (Bases requires frontmatter). Designing notes in isolation without considering relationships. **Backticked vault entity names** — `` `Workflow.md` `` in prose is a dead reference; `[[Workflow]]` is a living graph node.
+
+For the full linking decision table and schema authority rules, see `vault-curator/references/linking-discipline.md`.
 
 ---
 

--- a/plugins/archivist/skills/vault-curator/SKILL.md
+++ b/plugins/archivist/skills/vault-curator/SKILL.md
@@ -15,7 +15,7 @@ description: >
   Do NOT use for creating new templates, schemas, Bases queries, or vault structures
   (use vault-architect for those).
 metadata:
-  version: "1.10.0"
+  version: "1.11.0"
   plugin: "archivist"
   stage: "3"
 license: MIT
@@ -65,6 +65,7 @@ Before writing any note to the vault:
 1. **Frontmatter on line 1** — `---` must be the very first characters. A leading newline silently breaks Obsidian's property parsing and fileClass resolution. When using `obsidian append`, ensure content begins with `---` directly.
 2. **Linter compliance** — check `.obsidian/plugins/obsidian-linter/data.json` first (see vault-architect for key fields). Linter auto-reformats on save; non-compliant notes produce spurious git diffs.
 3. **Bulk validation**: `uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-architect/scripts/validate_frontmatter.py ${VAULT_PATH}`
+4. **Wikilinks over backticks** — every reference to another vault entity (note, fileClass, `.base` file, template, folder, canvas) uses `[[Target]]`. Backticks are for shell commands, CLI argument paths, property keys, YAML values, and code identifiers. See `references/linking-discipline.md`.
 
 ### Write Boundaries
 

--- a/plugins/archivist/skills/vault-curator/references/cli-patterns.md
+++ b/plugins/archivist/skills/vault-curator/references/cli-patterns.md
@@ -78,6 +78,26 @@ obsidian move file="Note Title.md" to="New/Folder"
 | "Unknown command" | CLI version too old | Run `obsidian help` to check available commands |
 | Empty results from search/tags | Vault index not ready | Wait a moment, retry, or use Grep as fallback |
 
+## Graph Traversal Commands
+
+Use these for authoring, discovery, and health workflows. They require Obsidian's index (CLI must be running).
+
+| Command | Returns |
+|---------|---------|
+| `obsidian backlinks file="<name>"` | All notes linking TO this file |
+| `obsidian links file="<name>"` | All outgoing links FROM this file |
+| `obsidian unresolved` | Broken wikilinks vault-wide (add `sources=true` for source files) |
+| `obsidian orphans` | Files with no incoming links — MOC candidates or deletable |
+| `obsidian deadends` | Files with no outgoing links — cross-referencing candidates |
+
+**When to use:**
+- **Before authoring** a note: `backlinks` to understand what already connects to a target
+- **After rename / `obsidian move`**: `unresolved sources=true` to catch any broken references
+- **Health check**: `orphans` for MOC gap analysis; `deadends` for under-connected notes
+- **Discovery**: `links` to map a note's connection footprint before consolidating or moving it
+
+See `references/linking-discipline.md` for the full linking rationale and decision table.
+
 ## Fallback
 
 CLI requires Obsidian desktop app to be running. If unavailable, fall back to Grep/Glob/Read tools on vault files at `${VAULT_PATH}`.

--- a/plugins/archivist/skills/vault-curator/references/linking-discipline.md
+++ b/plugins/archivist/skills/vault-curator/references/linking-discipline.md
@@ -1,0 +1,101 @@
+# Linking Discipline in Obsidian Vaults
+
+Every reference to another vault entity in authored content should be a wikilink. This powers backlinks, graph discovery, rename-safe updates, and agent navigation across sessions.
+
+## The Rule
+
+**Default to `[[Target]]` for any vault entity reference.** Use backticks only for code identifiers, shell commands, YAML property keys, and CLI argument paths.
+
+## Why It Matters
+
+- **Backlinks** — `[[Target]]` creates a reverse edge visible in Obsidian's Backlinks pane and queryable via `obsidian backlinks file="Target"`. Backticks create nothing.
+- **Graph discoverability** — the node graph shows connected clusters only from wikilinks. Backtick references are invisible to the graph.
+- **Rename-safe** — `obsidian move` updates wikilinks vault-wide atomically. Backticked filenames become dead references silently.
+- **Single source of truth** — linking to a canonical note means a reader can navigate there. The `.base` file's default view is the authoritative schema definition for a type; the fileClass note mirrors it.
+- **Agent navigation** — future archivist sessions can traverse the graph via `obsidian backlinks`/`links` to find context, but only for edges that exist as wikilinks.
+
+## Decision Table
+
+| Reference kind | Correct | Incorrect |
+|---|---|---|
+| fileClass note | `[[Meeting]]` | `` `Meeting` `` or `` `Meeting.md` `` |
+| Base file | `[[Meetings.base]]` | `` `Meetings.base` `` |
+| Template | `[[🛠 New Meeting]]` | `` `New Meeting` `` |
+| Folder note | `[[700 Notes/Workflows]]` | `` `700 Notes/Workflows/` `` |
+| Any other vault note | `[[Canvas Types]]` | `` `Canvas Types.md` `` |
+| CLI command in prose | `` `obsidian backlinks file="X"` `` | `[[X]]` inside code context |
+| YAML property key | `` `fileClass` `` | `[[fileClass]]` |
+| YAML property value (literal) | `` `workflow` `` | `[[workflow]]` |
+| Code block / shell example | keep as code | — |
+
+**The `` `fileClass:` `` / `[[Value]]` pattern:** In headings and prose that identify a note type, use backticks for the property key and a wikilink for the value that names a fileClass. Example: `` `fileClass:` [[Meeting]] ``.
+
+## Schema Authority in a Post-Bases Vault
+
+The `.base` file's **default view** is the canonical definition of a note type — its properties and their types live there. The metadata-menu fileClass note (typically in `900 📐Templates/920 File Classes/`) is a backing layer that mirrors the Base.
+
+**Drift resolution:** When a Base and its fileClass note disagree, the Base wins. Propose updates to the fileClass note to match.
+
+**Linking convention:** When prose references a type, link the Base first, fileClass second:
+- `[[Meetings.base]]` — schema definition
+- `[[Meeting]]` — metadata-menu backing (editor pickers, field ordering)
+
+**Workflow:** Change the Base's default view → update the fileClass YAML to match → never the reverse.
+
+## Graph CLI Commands
+
+Use these to surface connections during authoring and discovery sessions:
+
+```bash
+# Who links to this note?
+obsidian backlinks file="Types of Notes"
+
+# What does this note link to?
+obsidian links file="Types of Notes"
+
+# Broken wikilinks vault-wide (with source files)
+obsidian unresolved sources=true
+
+# Notes with no incoming links (orphans — MOC candidates or deletable)
+obsidian orphans
+
+# Notes with no outgoing links (dead-ends — cross-referencing candidates)
+obsidian deadends
+```
+
+**When to use each:**
+
+| Command | When |
+|---|---|
+| `backlinks` | Before authoring: understand what already references a target. After rename: check coverage. |
+| `links` | When reviewing a note: map its connection footprint. |
+| `unresolved` | Health checks, post-rename cleanup, after bulk file moves. |
+| `orphans` | Health checks, MOC gap analysis, pre-archival review. |
+| `deadends` | Cross-referencing candidates: notes that exist but don't participate in the graph. |
+
+## Anti-Patterns
+
+**Before-state (do not produce):**
+
+```markdown
+## Workflow Notes (`fileClass: workflow`)
+...
+### Views: `Workflows.base`
+```
+
+**After-state (target pattern):**
+
+```markdown
+## Workflow Notes (`fileClass:` [[Workflow]])
+...
+### Views: [[Workflows.base]]
+```
+
+**Canonical example:** `700 Notes/Notes/Types of Notes.md` in the user's vault demonstrates the full target pattern — registry table columns (fileClass, Folder, Template, Base), section headings, and inline Views references all use `[[...]]`.
+
+## Common Mistakes
+
+- Using backticks around `.base` filenames in the Views line of a type section
+- Using backticks for fileClass values in section headings instead of wikilinks
+- Referencing templates by descriptive name in prose without linking to the template note
+- Referencing folder paths with trailing slashes instead of linking to the folder note


### PR DESCRIPTION
…authority

Teach the archivist to default to wikilinks when authoring vault content and to use Obsidian's graph CLI commands for discovery.

Changes:
- agents/archivist.md: new Linking Discipline section (loaded every session) — rule, rationale, schema authority summary, pointer to reference
- vault-curator/SKILL.md: Write Quality Gate item 4 — wikilinks over backticks
- vault-architect/SKILL.md: Design Principles — link aggressively (Do), no backticked vault entities (Avoid), .base is canonical for schema
- vault-curator/references/linking-discipline.md: new deep reference — decision table, schema authority (Bases > fileClass), graph CLI commands, anti-patterns with before/after examples
- vault-curator/references/cli-patterns.md: Graph Traversal Commands section (backlinks, links, unresolved, orphans, deadends with when-to-use guide)
- vault-architect v1.9.0, vault-curator v1.11.0, plugin v1.17.0