### PR TITLE
feat(archivist): agent-native improvements v1.21.0

### DIFF
--- a/plugins/archivist/.claude-plugin/plugin.json
+++ b/plugins/archivist/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "archivist",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Personal Knowledge Management expert for Obsidian vaults with autonomous orchestration",
   "author": {
     "name": "J. Greg Williams",

--- a/plugins/archivist/.local.md.example
+++ b/plugins/archivist/.local.md.example
@@ -1,6 +1,10 @@
 <!-- PKM Plugin Configuration -->
 <!-- Copy this file to .local.md and customize for your vault -->
 
+<!-- ============================================================ -->
+<!-- OPTION A: Single vault (legacy format — always supported)    -->
+<!-- ============================================================ -->
+
 vault_path: /Users/username/Documents/MyVault
 daily_notes_path: Daily Notes
 templates_path: Templates
@@ -20,3 +24,29 @@ curator_write_zones: 700 Notes/, 800 Generated/, 500 ♽ Cycles/
 <!-- Directories intended for automated/generated output (forward compatibility — -->
 <!-- all writes still require confirmation until hook-based enforcement is available) -->
 designated_output_zones: 800 Generated/
+
+
+<!-- ============================================================ -->
+<!-- OPTION B: Multiple vaults (named-profile format)             -->
+<!-- Use this instead of the flat vault_path: key above.          -->
+<!-- The vaults: key takes precedence if both are present.        -->
+<!-- ============================================================ -->
+
+# vaults:
+#   personal:
+#     path: /Users/username/Documents/PersonalVault
+#     architect_write_zones: 900 📐Templates/, _vault-profile.md
+#     curator_write_zones: 700 Notes/, 800 Generated/
+#     designated_output_zones: 800 Generated/
+#
+#   work:
+#     path: /Users/username/Documents/WorkVault
+#     architect_write_zones: Templates/, _vault-profile.md
+#     curator_write_zones: Notes/, Generated/
+#     designated_output_zones: Generated/
+
+<!-- Multi-vault selection logic (when vaults: is defined):          -->
+<!--   1. If $PWD is inside one vault's path → auto-select that vault -->
+<!--   2. If $PWD matches no vault → present named choices via prompt  -->
+<!--   3. If only one vault is defined → auto-select without prompt    -->
+<!-- Vault paths support ~ expansion.                                  -->

--- a/plugins/archivist/README.md
+++ b/plugins/archivist/README.md
@@ -62,20 +62,20 @@ MIT
 
 ## Agent: archivist
 
-### Agent-Native Audit — 2026-04-13
+### Agent-Native Audit — 2026-04-14
 
 Overall score: **71%** ([#160](https://github.com/totallyGreg/claude-mp/issues/160))
 
 | Principle | Score | % | Status |
 |-----------|-------|---|--------|
-| Action Parity | 6/6 | 100% | ✅ |
+| Shared Workspace | 7.5/8 | 94% | ✅ |
 | Capability Discovery | 6.5/7 | 93% | ✅ |
-| Shared Workspace | 7/8 | 87.5% | ✅ |
-| Tools as Primitives | 9/12 | 75% | ⚠️ |
-| UI Integration | 5/8 | 62.5% | ⚠️ |
-| CRUD Completeness | 7/12 | 58% | ⚠️ |
-| Context Injection | 12/22 | 54.5% | ⚠️ |
-| Prompt-Native Features | 8/20 | 40% | ❌ |
+| Prompt-Native Features | 28/32 | 88% | ✅ |
+| Tools as Primitives | 8/10 | 80% | ✅ |
+| Context Injection | 5/7 | 71% | ⚠️ |
+| CRUD Completeness | 4/7 | 57% | ⚠️ |
+| Action Parity | 12/24 | 50% | ⚠️ |
+| UI Integration | 6/17 | 35% | ❌ |
 
 ### Version History
 

--- a/plugins/archivist/README.md
+++ b/plugins/archivist/README.md
@@ -54,7 +54,7 @@ Progressive disclosure:
 
 ## Version
 
-1.20.0
+1.21.0
 
 ## License
 
@@ -81,6 +81,7 @@ Overall score: **71%** ([#160](https://github.com/totallyGreg/claude-mp/issues/1
 
 | Version | Date | Issue | Summary |
 |---------|------|-------|---------|
+| 1.21.0 | 2026-04-14 | [#160](https://github.com/totallyGreg/claude-mp/issues/160) | Agent-native improvements: init vault signals (Context Injection), delete workflows (CRUD), multi-vault .local.md (Shared Workspace), --no-write primitives (Tools as Primitives), index refresh after writes (UI Integration), /help + /workflows commands (Capability Discovery + Action Parity) |
 | 1.20.0 | 2026-04-13 | [#160](https://github.com/totallyGreg/claude-mp/issues/160) | Add workflow classification (known vs novel detection) and session learning tables (Known Workflows + Workflow Candidates) to _vault-profile.md; promotion rule graduates 2+ occurrence candidates to workflow notes |
 | 1.19.0 | 2026-04-09 | - | Add Canvas Types taxonomy (Impact/Workflow/Architecture/Knowledge Maps) and Change Impact Map workflow |
 
@@ -88,7 +89,7 @@ Overall score: **71%** ([#160](https://github.com/totallyGreg/claude-mp/issues/1
 
 ### Current Metrics
 
-**Score: 93/100** (Good) — 2026-04-11
+**Score: 93/100** (Good) — 2026-04-14
 
 | Concs | Complx | Spec | Progr | Descr |
 |-------|--------|------|-------|-------|
@@ -98,6 +99,7 @@ Overall score: **71%** ([#160](https://github.com/totallyGreg/claude-mp/issues/1
 
 | Version | Date | Issue | Summary | Concs | Complx | Spec | Progr | Descr | Score |
 |---------|------|-------|---------|-------|--------|------|-------|-------|-------|
+| 1.10.0 | 2026-04-14 | [#160](https://github.com/totallyGreg/claude-mp/issues/160) | Add vault-analysis-checks.md (analyze_vault.py check reference) and frontmatter-schema-reference.md (validate_frontmatter.py fields, severity, violations); update SKILL.md to reference both | 79 | 90 | 100 | 100 | 100 | 93 |
 | 1.9.0 | 2026-04-11 | - | Add linking discipline to Design Principles: link aggressively, no backticked vault entities; schema authority: .base default view is canonical, fileClass mirrors it; pointer to linking-discipline.md | 79 | 90 | 100 | 100 | 100 | 93 |
 | 1.8.0 | 2026-03-31 | - | Add Vault Profiling workflow, Write Boundaries section, replace hardcoded vault path with ${VAULT_PATH} | 80 | 90 | 100 | 100 | 100 | 94 |
 | 1.7.0 | 2026-03-28 | - | Add Linter plugin config read to Vault Discovery; read .obsidian/plugins/obsidian-linter/data.json before writing notes | 98 | 100 | 100 | 100 | 100 | 99 |
@@ -116,7 +118,7 @@ Overall score: **71%** ([#160](https://github.com/totallyGreg/claude-mp/issues/1
 
 ### Current Metrics
 
-**Score: 96/100** (Excellent) — 2026-04-11
+**Score: 96/100** (Excellent) — 2026-04-14
 
 | Concs | Complx | Spec | Progr | Descr |
 |-------|--------|------|-------|-------|
@@ -126,6 +128,7 @@ Overall score: **71%** ([#160](https://github.com/totallyGreg/claude-mp/issues/1
 
 | Version | Date | Issue | Summary | Concs | Complx | Spec | Progr | Descr | Score |
 |---------|------|-------|---------|-------|--------|------|-------|-------|-------|
+| 1.12.0 | 2026-04-14 | [#160](https://github.com/totallyGreg/claude-mp/issues/160) | Add collection-health-criteria.md reference; add --no-write to generate_canvas.py, merge_notes.py, redirect_links.py (50-file cap on redirect); add --node-width/--node-height/--coverage-threshold CLI args; add fileClass group nodes + edge direction markers to canvas | 83 | 100 | 100 | 100 | 100 | 96 |
 | 1.11.0 | 2026-04-11 | - | Add Wikilinks over backticks rule to Write Quality Gate; graph traversal commands to cli-patterns.md; create linking-discipline.md reference (decision table, schema authority, graph CLI commands) | 83 | 100 | 100 | 100 | 100 | 96 |
 | 1.10.0 | 2026-04-01 | - | Demote Write Boundaries to H3; add Base Files and File Relocation rules to cli-patterns.md; offload verbose docs to references/ | 98 | 100 | 100 | 100 | 100 | 99 |
 | 1.9.4 | 2026-03-31 | - | Add Write Boundaries section for vault-aware permission zones | 80 | 90 | 100 | 100 | 100 | 94 |

--- a/plugins/archivist/agents/archivist.md
+++ b/plugins/archivist/agents/archivist.md
@@ -223,13 +223,22 @@ All metadata, consolidation, discovery, and visualization workflows begin with s
 ### Consolidation: Merge Notes
 1. Load reference: Read `${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/references/consolidation-protocol.md`
 2. Git checkpoint: `bash cd ${VAULT_PATH} && git add "${VAULT_PATH}" && git commit -m "Pre-consolidation checkpoint"`
-2. Dry-run: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/merge_notes.py ${VAULT_PATH} --source "${SOURCE}" --target "${TARGET}" --dry-run`
-3. Present frontmatter changes and conflicts to user
-4. Resolve conflicts with user input
-5. Execute merge (remove --dry-run)
-6. Run link redirect: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/redirect_links.py ${VAULT_PATH} --old "${OLD_NAME}" --new "${NEW_NAME}" --dry-run`
-7. Show affected files, get confirmation, execute redirect
-8. Delete source note after confirmed redirect
+3. Dry-run: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/merge_notes.py ${VAULT_PATH} --source "${SOURCE}" --target "${TARGET}" --dry-run`
+4. Present frontmatter changes and conflicts to user
+5. Resolve conflicts with user input
+6. Get merged content: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/merge_notes.py ${VAULT_PATH} --source "${SOURCE}" --target "${TARGET}" --no-write`
+7. If result has errors, stop and report. Apply any user-resolved conflicts to `target_content` string.
+8. Write merged target with Write tool: write `result.target_content` to `${VAULT_PATH}/${TARGET}`
+9. `# Trigger Obsidian index refresh — resolves backlink latency after write`
+   `bash obsidian search query="${TARGET_STEM}" format=json limit=1`
+10. Run link redirect: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/redirect_links.py ${VAULT_PATH} --old "${OLD_NAME}" --new "${NEW_NAME}" --dry-run`
+11. Show affected files, get confirmation
+12. Apply redirects: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/redirect_links.py ${VAULT_PATH} --old "${OLD_NAME}" --new "${NEW_NAME}" --no-write`
+    - If `status: too_many` (>50 files): get explicit user approval, then run without `--no-write`
+    - Otherwise: apply each `affected_files[].content_after` with Edit tool
+13. `# Trigger Obsidian index refresh after link redirects`
+    `bash obsidian search query="${NEW_NAME}" format=json limit=1`
+14. Delete source note after confirmed redirect
 
 ### Discovery: Find Related Notes
 1. Run scope selection (or use the target note's folder)
@@ -257,8 +266,11 @@ All metadata, consolidation, discovery, and visualization workflows begin with s
 1. Run scope selection
 2. Dry-run: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/generate_canvas.py ${VAULT_PATH} --scope "${SCOPE}" --dry-run`
 3. Review node/edge counts with user
-4. Execute (remove --dry-run) to write `.canvas` file
-5. Report canvas path and stats
+4. Generate canvas data: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/generate_canvas.py ${VAULT_PATH} --scope "${SCOPE}" --no-write`
+5. If result has errors, stop and report. Otherwise, write canvas file with Write tool: write `json.dumps(result.canvas_data)` to `${VAULT_PATH}/${result.canvas_path}`
+6. `# Trigger Obsidian index refresh — resolves backlink latency after write`
+   `bash obsidian search query="${CANVAS_STEM}" format=json limit=1`
+7. Report canvas path and stats
 
 ### Change Impact Map: Consult & Update
 

--- a/plugins/archivist/agents/archivist.md
+++ b/plugins/archivist/agents/archivist.md
@@ -106,6 +106,21 @@ At the start of every session, run these steps in order before doing anything el
 
 4. **Verify vault connection** — `bash obsidian vault` (returns vault name + file count). If it fails, fall back to file tools (Glob, Grep, Read) for all operations.
 
+5. **Quick Vault Signals** — Run lightweight checks to surface the highest-priority issue before the user speaks. Skip any step if the CLI is unavailable (do not hard-fail):
+
+   a. **Orphan count:** `bash obsidian orphans | wc -l` → store as `orphan_count`. If CLI unavailable, skip.
+   b. **Unhealthy collections (fast scan):** First get candidates: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/check_collection_health.py ${VAULT_PATH} --dry-run`. Then for each candidate folder, run `check_collection_health.py --folder <folder>` and collect any with `health: partial` or `health: missing_infrastructure`. If vault has no collections (empty candidate list), skip.
+
+   **Opening prompt based on signals:**
+   - If `orphan_count > 20` AND unhealthy collections found: "Your vault has **N orphaned notes** and **M collections** with missing infrastructure. Would you like to start with the orphans or the collection issues?"
+   - If only `orphan_count > 20`: "Your vault has **N orphaned notes** that aren't connected to the knowledge graph. Would you like to find homes for them?"
+   - If only unhealthy collections: "Found **M collections** with missing infrastructure: [names]. Would you like to scaffold the missing parts?"
+   - If no issues: "Vault looks healthy — what would you like to work on?"
+
+   **Fallback:** If CLI is unavailable for both checks, open with: "Ready to work on your vault — what would you like to do?"
+
+   **Note:** See `references/collection-health-criteria.md` for health threshold definitions.
+
 ## Read Path (Always Fast, Never Permission-Gated)
 
 Reads never require user confirmation. Choose the fastest available method:
@@ -230,6 +245,7 @@ All metadata, consolidation, discovery, and visualization workflows begin with s
 7. If result has errors, stop and report. Apply any user-resolved conflicts to `target_content` string.
 8. Write merged target with Write tool: write `result.target_content` to `${VAULT_PATH}/${TARGET}`
 9. `# Trigger Obsidian index refresh — resolves backlink latency after write`
+   `# If CLI unavailable, backlinks may take 1–5s to appear; continue without error`
    `bash obsidian search query="${TARGET_STEM}" format=json limit=1`
 10. Run link redirect: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/redirect_links.py ${VAULT_PATH} --old "${OLD_NAME}" --new "${NEW_NAME}" --dry-run`
 11. Show affected files, get confirmation
@@ -237,6 +253,7 @@ All metadata, consolidation, discovery, and visualization workflows begin with s
     - If `status: too_many` (>50 files): get explicit user approval, then run without `--no-write`
     - Otherwise: apply each `affected_files[].content_after` with Edit tool
 13. `# Trigger Obsidian index refresh after link redirects`
+    `# If CLI unavailable, backlinks may take 1–5s to appear; continue without error`
     `bash obsidian search query="${NEW_NAME}" format=json limit=1`
 14. Delete source note after confirmed redirect
 
@@ -269,6 +286,7 @@ All metadata, consolidation, discovery, and visualization workflows begin with s
 4. Generate canvas data: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/generate_canvas.py ${VAULT_PATH} --scope "${SCOPE}" --no-write`
 5. If result has errors, stop and report. Otherwise, write canvas file with Write tool: write `json.dumps(result.canvas_data)` to `${VAULT_PATH}/${result.canvas_path}`
 6. `# Trigger Obsidian index refresh — resolves backlink latency after write`
+   `# If CLI unavailable, backlinks may take 1–5s to appear; continue without error`
    `bash obsidian search query="${CANVAS_STEM}" format=json limit=1`
 7. Report canvas path and stats
 

--- a/plugins/archivist/agents/archivist.md
+++ b/plugins/archivist/agents/archivist.md
@@ -440,10 +440,10 @@ ALWAYS ask user confirmation before:
 | `suggest_properties.py` | `<vault-path> <note-path> [--min-confidence <pct>]` |
 | `detect_schema_drift.py` | `<vault-path> --file-class <class> [--scope <path>] [--dry-run]` |
 | `find_related.py` | `<vault-path> <note-path> [--scope <path>] [--top <n>]` |
-| `generate_canvas.py` | `<vault-path> --scope <path> [--output <name>] [--max-nodes <n>] [--dry-run]` |
+| `generate_canvas.py` | `<vault-path> --scope <path> [--output <name>] [--max-nodes <n>] [--node-width <px>] [--node-height <px>] [--no-write] [--dry-run]` |
 | `find_similar_notes.py` | `<vault-path> --scope <path> [--min-similarity <pct>] [--max-groups <n>] [--dry-run]` |
-| `merge_notes.py` | `<vault-path> --source <path> --target <path> [--dry-run]` |
-| `redirect_links.py` | `<vault-path> --old <name> --new <name> [--scope <path>] [--dry-run]` |
-| `check_collection_health.py` | `<vault-path> [--scope <path>] [--folder <path>] [--dry-run]` |
+| `merge_notes.py` | `<vault-path> --source <path> --target <path> [--no-write] [--dry-run]` |
+| `redirect_links.py` | `<vault-path> --old <name> --new <name> [--scope <path>] [--no-write] [--dry-run]` |
+| `check_collection_health.py` | `<vault-path> [--scope <path>] [--folder <path>] [--coverage-threshold <pct>] [--dry-run]` |
 
 Run via: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/<script> <args>`

--- a/plugins/archivist/agents/archivist.md
+++ b/plugins/archivist/agents/archivist.md
@@ -366,6 +366,47 @@ Audit all Collection Folder Pattern instances in scope:
 5. Execute with progress tracking
 6. Validate post-migration
 
+### Delete Workflows
+
+**Rule:** Delete is always a structural-zone operation requiring explicit confirmation regardless of zone. Always run a dependency check before deleting. Never delete without presenting impact first.
+
+#### Delete Canvas
+
+Canvas files are generated outputs with no dependents — nothing embeds or wikilinks to them by convention.
+
+1. Confirm once: "Delete `<canvas-path>`? This cannot be undone."
+2. After confirmation: `bash rm "${VAULT_PATH}/<canvas-path>"`
+3. `# Trigger Obsidian index refresh after delete`
+   `# If CLI unavailable, backlinks may take 1–5s to update; continue without error`
+   `bash obsidian search query="${CANVAS_STEM}" format=json limit=1`
+4. Log deletion in session notes.
+
+#### Delete Template
+
+Templates may be referenced by wikilinks in notes or QuickAdd/Templater configurations (note: this check scans wikilinks only — QuickAdd/Templater plugin config JSON is not scanned).
+
+1. Dependency check: `bash grep -r "\[\[${TEMPLATE_NAME}\]\]" "${VAULT_PATH}" --include="*.md" -l`
+2. If references found: present list of impacted notes to user. Require explicit confirmation before proceeding.
+3. If no references: confirm once: "No notes reference `[[${TEMPLATE_NAME}]]`. Delete the template?"
+4. After confirmation: `bash rm "${VAULT_PATH}/<template-path>"`
+5. `# Trigger Obsidian index refresh after delete`
+   `bash obsidian search query="${TEMPLATE_NAME}" format=json limit=1`
+6. Log deletion in session notes.
+
+#### Delete Bases File
+
+Bases files are embedded in folder notes. Deleting without removing embeds causes broken embed displays.
+
+1. Dependency check: `bash grep -r "!\[\[${BASES_NAME}\.base" "${VAULT_PATH}" --include="*.md" -l`
+2. Present all impacted folder notes to user. Require confirmation before proceeding.
+3. Offer to remove the `![[<BasesName>.base#...]]` embed from each impacted folder note (separate confirmation per file or bulk approval).
+4. If user approves embed removal: edit each folder note with Edit tool to remove the embed line.
+5. After embeds removed: confirm once to delete the `.base` file.
+6. `bash rm "${VAULT_PATH}/900 📐Templates/970 Bases/${BASES_NAME}.base"`
+7. `# Trigger Obsidian index refresh after delete`
+   `bash obsidian search query="${BASES_NAME}" format=json limit=1`
+8. Log deletion in session notes.
+
 ## Post-Workflow
 
 After completing any workflow, run two follow-up steps:
@@ -455,7 +496,7 @@ ALWAYS ask user confirmation before:
 - Bulk changes (>10 files)
 - Operations on large scopes (>500 notes)
 - Merging notes or redirecting links (always dry-run first)
-- Deleting any note (only after link redirect is confirmed)
+- **Deleting any vault file** — always run dependency check first, present impact, then require explicit confirmation. This applies regardless of zone (even `designated_output_zones`).
 
 ## Scripts
 

--- a/plugins/archivist/agents/archivist.md
+++ b/plugins/archivist/agents/archivist.md
@@ -93,7 +93,19 @@ At the start of every session, run these steps in order before doing anything el
    - Continue initialization with zones unconfigured (all writes require confirmation until profiling runs).
 
    **If `.local.md` exists**, parse:
+
+   *Multi-vault detection:* Check if the file contains a `vaults:` key with 2+ named vault profiles.
+   - If `vaults:` is present and has **1 entry**: auto-select it without prompting.
+   - If `vaults:` is present and has **2+ entries**:
+     - Expand `~` in each vault's `path:` field.
+     - Check if `$PWD` starts with any vault's path. If exactly one matches → auto-select it silently.
+     - If no match (or multiple matches): use AskUserQuestion to present the vault names and ask which to use.
+   - If both `vaults:` and a flat `vault_path:` are present: use `vaults:` and warn the user about the redundant `vault_path:` key.
+
+   *Single-vault (legacy format):*
    - `vault_path:` — if absent or still the placeholder (`/Users/username/Documents/MyVault`), ask for the real path and update the file with the Write tool before continuing
+
+   *After vault is selected, load its zones:*
    - `architect_write_zones:` — comma-separated vault-relative paths where vault-architect may write
    - `curator_write_zones:` — comma-separated vault-relative paths where vault-curator may write
    - `designated_output_zones:` — free-write zone (no confirmation needed for creates)

--- a/plugins/archivist/commands/help.md
+++ b/plugins/archivist/commands/help.md
@@ -1,0 +1,15 @@
+---
+name: help
+description: List all available archivist slash commands with a one-line description of each.
+---
+
+Invoke the archivist agent to list all available slash commands.
+
+The agent should:
+1. Initialize normally (load skills, discover vault location)
+2. Read all files matching `${CLAUDE_PLUGIN_ROOT}/commands/*.md` (Glob)
+3. For each command file, extract the `description` field from its YAML frontmatter
+4. Present a formatted table with two columns: the slash command (e.g., `/canvas`) and its description
+5. Note that deeper capability documentation is available in the skill files:
+   - `${CLAUDE_PLUGIN_ROOT}/skills/vault-architect/SKILL.md` — vault structure, templates, schemas
+   - `${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/SKILL.md` — content evolution, consolidation, visualization

--- a/plugins/archivist/commands/workflows.md
+++ b/plugins/archivist/commands/workflows.md
@@ -1,0 +1,24 @@
+---
+name: workflows
+description: Show Known Workflows and Workflow Candidates tables from the vault profile.
+---
+
+Invoke the archivist agent to display vault workflow intelligence from `_vault-profile.md`.
+
+The agent should:
+1. Initialize normally (load skills, discover vault, load `_vault-profile.md`)
+2. Based on what is found in `_vault-profile.md`:
+
+   **If the file exists and contains workflow tables:**
+   - Extract and present the `## Known Workflows` table (named workflows with call counts, avg steps, last called date)
+   - Extract and present the `## Workflow Candidates` table (novel requests not yet named)
+   - Remind the user: candidates with 2+ occurrences can be promoted — offer to run the promotion workflow if any qualify
+
+   **If `_vault-profile.md` is absent:**
+   - Explain that vault profiling hasn't run yet and the workflow tables will be empty until it does
+   - Offer to run vault profiling now to initialize the profile
+
+   **If `_vault-profile.md` exists but has no workflow tables:**
+   - Report that the tables are empty (common on a freshly profiled vault)
+   - Explain that tables populate as workflows are used in sessions
+   - Offer to run a workflow now to seed the Known Workflows table

--- a/plugins/archivist/docs/plans/2026-03-31-002-fix-health-check-workflow-gaps-plan.md
+++ b/plugins/archivist/docs/plans/2026-03-31-002-fix-health-check-workflow-gaps-plan.md
@@ -1,0 +1,200 @@
+---
+title: "fix: Resolve health check workflow friction — script defaults, agent context loss, and result clarity"
+type: fix
+status: completed
+date: 2026-03-31
+---
+
+# fix: Resolve health check workflow friction — script defaults, agent context loss, and result clarity
+
+## Overview
+
+The `/health` command and subsequent workflows (duplicates, collection fixes, orphan triage) have significant friction: scripts return capped results without the agent requesting more, orphan metrics are inconsistent between tools, the health command produces no structured summary, and multi-step remediation loses context across agent respawns. This plan addresses the gaps observed in a real health check session on 2026-03-31.
+
+## Problem Frame
+
+A user ran `/archivist:health` to assess vault health, then wanted to drill into duplicates and create a vault profile. The session required 4+ agent spawns, hit permission denials, lost accumulated context between agents, and produced inconsistent orphan counts (3,020 vs 846) with no explanation of the discrepancy. The duplicate finder capped at 20 groups out of 325 because the agent never passed `--max-groups`. Collection health found only 2 collections when dozens of folders have collection-like structure. The vault profile creation required 3 agent attempts before succeeding.
+
+These are not fundamental architecture issues — they're workflow instruction gaps in the agent and command definitions that cause the agent to use tools suboptimally.
+
+## Requirements Trace
+
+- R1. Health command produces a structured, actionable report with consistent metrics and explained discrepancies
+- R2. Script invocations use appropriate defaults for vault-scale operations (not development defaults)
+- R3. Multi-step remediation workflows preserve context within a single agent session instead of requiring respawns
+- R4. Collection detection covers folders with collection-like patterns, not just those with explicit infrastructure
+
+## Scope Boundaries
+
+- No changes to Python scripts — only agent/command/skill markdown files
+- No new Python dependencies or scripts
+- Does not address permission zone enforcement (covered by plan 001)
+- Does not address vault profile creation (covered by plan 001, Unit 1)
+- Focus is on the health → diagnose → remediate flow, not all archivist workflows
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `commands/health.md` — thin wrapper, 4 lines of instruction, no structured output guidance
+- `agents/archivist.md` — orchestrator loads both skills, routes workflows, has script usage tables
+- `find_similar_notes.py` — `--max-groups` defaults to 20, supports any value
+- `check_collection_health.py` — detects collections by folder note presence, misses folders without folder notes
+- `obsidian orphans` CLI command — counts notes with no *incoming* links
+- `analyze_vault.py` — counts notes with no links *in or out* (fully isolated)
+
+### Friction Points Observed (2026-03-31 session)
+
+1. **Orphan count inconsistency**: CLI `obsidian orphans` = 3,020 (no incoming links). `analyze_vault.py` = 846 (no links at all). Neither the health command nor the agent explains this difference.
+2. **Duplicate finder capped at 20/325**: Agent invoked `find_similar_notes.py` without `--max-groups`, getting default 20. The script found 325 groups total. Agent should pass `--max-groups 100` for health assessments.
+3. **Collection detection gaps**: `check_collection_health.py` only detected 2 collections (000 Pillars, 800 Generated). Folders like People, Companies, Meetings, Tools, Terminology have collection-like patterns (shared fileClass, consistent structure) but no folder notes, so they're invisible to the script.
+4. **Context loss across agent spawns**: Health → duplicates → vault profile required 3 separate agent spawns. Each lost the accumulated vault context, metrics, and user decisions from prior steps.
+5. **Permission denials on write**: Agent couldn't write `_vault-profile.md` — both Bash and Write tool permissions were denied. No fallback or guidance in the agent instructions.
+6. **Health output is unstructured prose**: No summary table, no priority tiers, no "here's what to fix first" — just raw script output interpreted ad hoc.
+
+## Key Technical Decisions
+
+- **Fix in command and agent instructions, not scripts**: The scripts already support the needed parameters (`--max-groups`, `--scope`). The gap is that agent/command instructions don't guide the agent to use them appropriately. Fixing instructions is lower-risk and faster than modifying Python.
+
+- **Add a "Health Report Template" to the health command**: Rather than letting the agent improvise report structure, define the expected output format — summary table, metric explanations, prioritized issues, next actions. This makes reports consistent across sessions.
+
+- **Add "Continuation Workflows" to the health command**: Instead of ending with "offer to fix top issues" (which requires the user to respawn the agent), define explicit follow-on workflows that run within the same agent session: "drill into duplicates", "fix collection health", "triage orphans".
+
+- **Explain orphan metric discrepancy in the health template**: Document that `obsidian orphans` counts notes with no incoming links (may still link out), while `analyze_vault.py` counts fully isolated notes (no links in or out). Present both with labels.
+
+- **Add "candidate collections" detection guidance**: When `check_collection_health.py` finds few collections, instruct the agent to also scan for folders with 10+ notes sharing a fileClass or consistent frontmatter pattern — these are collection candidates that need infrastructure (folder note, Bases file).
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should we modify the Python scripts?** → No. The scripts already support the needed parameters. The gap is in how the agent invokes them.
+- **Should health run in the main context or as a subagent?** → As a subagent (current behavior via `/health` command), but with structured output that the parent can act on. The key fix is making the subagent's session long enough to include follow-on workflows.
+
+### Deferred to Implementation
+
+- Exact threshold for "candidate collection" detection (10+ notes with shared fileClass is a starting point)
+- Whether the health report should be saved to a vault file (e.g., `800 Generated/health-report-YYYY-MM-DD.md`) — useful for tracking trends but adds write complexity
+
+## Implementation Units
+
+- [ ] **Unit 1: Improve health command with structured report template and continuation workflows**
+
+  **Goal:** Replace the thin health command with structured output guidance and in-session follow-on workflows.
+
+  **Requirements:** R1, R3
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `commands/health.md`
+
+  **Approach:**
+  - Add a "Report Template" section to the health command that defines the expected output structure: summary scorecard table (metric | value | status), metric explanations (especially orphan count discrepancy), prioritized issue list with tiers (Critical / Structural / Housekeeping), and a numbered menu of continuation workflows
+  - Add continuation workflows that run within the same agent session:
+    1. "Deep-dive duplicates" → run `find_similar_notes.py` with `--max-groups 100` on a user-selected scope
+    2. "Fix collection health" → run `check_collection_health.py` then scaffold missing infrastructure
+    3. "Triage orphans" → scope to a specific import folder, batch-review orphans
+    4. "Schema drift detection" → pick a fileClass, run `detect_schema_drift.py`
+    5. "Create/update vault profile" → run vault profiling workflow
+  - Each continuation workflow should be a self-contained instruction block that the agent can follow without needing to respawn
+
+  **Patterns to follow:**
+  - Existing `commands/vault.md` structure
+  - Existing workflow sections in `agents/archivist.md` (Consolidation: Find Duplicates, etc.)
+
+  **Test scenarios:**
+  - Happy path: User runs `/health` → agent produces structured report with summary table, explained metrics, prioritized issues, and numbered continuation menu
+  - Happy path: User selects "Deep-dive duplicates" from continuation menu → agent runs duplicate finder with `--max-groups 100` within same session, no respawn needed
+  - Edge case: All health metrics are clean (no orphans, no duplicates) → report shows healthy status, continuation menu still available for proactive workflows
+  - Edge case: Script execution fails (uv not installed, Python version mismatch) → agent reports the failure clearly and suggests manual alternatives
+
+  **Verification:**
+  - Health command produces a consistent, structured report with summary table
+  - Continuation workflows execute within the same agent session
+  - Orphan count discrepancy is explained in the report
+
+- [ ] **Unit 2: Fix script invocation defaults in agent orchestration**
+
+  **Goal:** Update agent workflow instructions to use vault-appropriate script parameters instead of development defaults.
+
+  **Requirements:** R2
+
+  **Dependencies:** None (can be implemented in parallel with Unit 1)
+
+  **Files:**
+  - Modify: `agents/archivist.md` (Consolidation: Find Duplicates section, Vault Analysis section, Collection Health Check section)
+
+  **Approach:**
+  - In "Consolidation: Find Duplicates" workflow: change the `find_similar_notes.py` invocation to include `--max-groups 100` by default. Add a note: "For health assessments (broad survey), use `--max-groups 100`. For targeted duplicate resolution (acting on results), use `--max-groups 20` or the default."
+  - In "Vault Analysis" section: add a step after running `analyze_vault.py` to also run `obsidian orphans` and reconcile the two orphan counts. Add explanation text: "analyze_vault.py counts fully isolated notes (no links in or out). `obsidian orphans` counts notes with no incoming links (may still link out). Present both with clear labels."
+  - In "Collection Health Check" section: after running `check_collection_health.py`, add a "Candidate Collections" scan step: "If fewer than 5 collections are detected, scan top-level folders for collection candidates — folders with 10+ notes sharing a `fileClass` value or consistent frontmatter pattern. Report these as 'potential collections needing infrastructure.'"
+
+  **Patterns to follow:**
+  - Existing script invocation patterns in `agents/archivist.md`
+  - Script CLI documentation in `skills/vault-curator/references/available-scripts.md`
+
+  **Test scenarios:**
+  - Happy path: Agent runs duplicate finder during health check → passes `--max-groups 100`, gets full picture instead of capped at 20
+  - Happy path: Agent runs vault analysis → reports both orphan metrics with labels explaining the difference
+  - Happy path: Collection health finds 2 formal collections → agent scans for candidates, identifies Tools (100+ notes with fileClass=tool) as a candidate collection
+  - Edge case: Vault has many formal collections (>5) → candidate scan is skipped (not needed)
+  - Edge case: No folders meet the candidate threshold (10+ notes with shared fileClass) → agent reports "no candidate collections found"
+
+  **Verification:**
+  - Duplicate finder returns 100+ groups instead of 20 for health assessments
+  - Orphan report shows two metrics with explanations
+  - Collection health report includes candidate collections when formal collection count is low
+
+- [ ] **Unit 3: Add write failure fallback guidance to agent**
+
+  **Goal:** Give the agent explicit fallback instructions when write operations are denied, so it doesn't stall on permission denials.
+
+  **Requirements:** R3
+
+  **Dependencies:** None (can be implemented in parallel)
+
+  **Files:**
+  - Modify: `agents/archivist.md` (add a "Write Fallback" section near Bounded Autonomy)
+
+  **Approach:**
+  - Add a "Write Fallback" section that instructs the agent:
+    1. If `Write` tool is denied → try `obsidian create path="..." content="..." overwrite silent` via Bash
+    2. If Bash is also denied → compose the file content in the response and ask the user to save it manually, providing the exact path
+    3. Never stall silently on permission denial — always try the next fallback or communicate clearly
+  - Add to the vault profile creation workflow: "If unable to write `_vault-profile.md` after trying both Write and Bash, output the composed content and ask the user to save it"
+
+  **Patterns to follow:**
+  - Existing "Verify vault connection" fallback pattern in initialization (step 4: "If it fails, fall back to file tools")
+
+  **Test scenarios:**
+  - Happy path: Write tool works → file is saved normally
+  - Edge case: Write tool denied → agent tries Bash with `obsidian create` → succeeds
+  - Edge case: Both Write and Bash denied → agent outputs composed content with path, asks user to save
+  - Edge case: Bash works but `obsidian create` fails (app not running) → agent falls back to `cat > path` via Bash or outputs content
+
+  **Verification:**
+  - Agent never stalls silently when writes are denied
+  - All write operations have a documented fallback chain
+
+## System-Wide Impact
+
+- **Interaction graph:** Changes are contained to the health command and agent orchestration. No new tools, scripts, or dependencies. The health command becomes a richer entry point that chains into existing workflows.
+- **Error propagation:** Write fallback chain ensures graceful degradation. Script failures already have fallback guidance in the agent.
+- **State lifecycle risks:** None — no new state files or persistent data. Health reports are ephemeral (shown in agent output, not saved to vault unless explicitly requested).
+- **API surface parity:** The health command's output format changes, but it's consumed by humans (not other tools), so there's no breaking change.
+- **Unchanged invariants:** All Python scripts remain unchanged. Vault-architect and vault-curator skill files are not modified. The `.local.md` schema is not modified.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Health command instructions become too long, overwhelming the agent's context | Keep instructions focused — report template + continuation menu + 5 workflow blocks. Total should be under 150 lines. |
+| Agent still doesn't follow `--max-groups 100` guidance | The instruction is explicit and in the exact invocation line. If it still fails, the next step would be changing the script's default. |
+| Candidate collection detection produces too many false positives | Threshold of 10+ notes with shared fileClass is conservative. Can be tuned based on usage. |
+
+## Sources & References
+
+- Plugin source: `/Users/gregwilliams/Documents/Projects/claude-mp/plugins/archivist/`
+- Session transcript: 2026-03-31 vault health check (this session)
+- Related plan: `docs/plans/2026-03-31-001-feat-archivist-permissions-vault-state-commands-plan.md`

--- a/plugins/archivist/docs/plans/2026-04-14-001-feat-agent-native-improvements-plan.md
+++ b/plugins/archivist/docs/plans/2026-04-14-001-feat-agent-native-improvements-plan.md
@@ -1,0 +1,489 @@
+---
+title: "feat: Agent-native architecture improvements from audit #160"
+type: feat
+status: active
+date: 2026-04-14
+---
+
+# feat: Agent-native architecture improvements from audit #160
+
+## Overview
+
+The archivist plugin scored 71% on an agent-native architecture audit (2026-04-13). This plan implements the improvements identified, organized by effort tier. Low-effort wins (documentation, init enrichment, new commands) are sequenced first; medium-effort structural changes (script primitive refactor, threshold externalization, CRUD gaps, multi-vault) follow. Longer-term items are explicitly deferred.
+
+## Problem Frame
+
+Eight agent-native principles were audited. Four are passing or near-passing (Action Parity 100%, Capability Discovery 93%, Shared Workspace 87.5%, Tools as Primitives 75%). Four need attention:
+- **Prompt-Native Features (40%)**: Policy and thresholds are buried in script docstrings and hardcoded constants — invisible to the agent and to users
+- **CRUD Completeness (58%)**: No delete path exists for templates, Bases files, or canvas files
+- **Context Injection (54.5%)**: Initialization is cold — orphan count, schema drift signals, and collection health are not surfaced until the user asks
+- **UI Integration (62.5%)**: Python write operations complete without triggering Obsidian's index refresh, causing 1–5s backlink latency after writes
+
+## Requirements Trace
+
+**Prompt-Native (R1, R2, R8)**
+- R1. Policy thresholds (similarity, coverage, node cap) visible in `references/` markdown
+- R2. Code-native feature criteria (collection health, vault analysis categories, frontmatter schema) documented in `references/`
+- R8. All hardcoded thresholds exposed as CLI args with documented defaults
+
+**UI Integration (R3)**
+- R3. Obsidian index refresh triggered after any Python write operation or agent file write
+
+**Context Injection (R4)**
+- R4. Init surfaces orphan count + schema drift pre-flight + unhealthy collections before first user prompt
+
+**Action Parity + Capability Discovery (R5, R6)**
+- R5. `/workflows` command exposes Known Workflows and Workflow Candidates tables
+- R6. `/commands/help.md` is the missing discovery mechanism
+
+**Tools as Primitives (R7)**
+- R7. `generate_canvas.py`, `merge_notes.py`, `redirect_links.py` return JSON, never write files; agent controls write decision
+
+**CRUD Completeness (R9)**
+- R9. Delete workflows exist for templates, Bases files, and canvas files
+
+**Shared Workspace (R10)**
+- R10. `.local.md` supports named vault profiles for multi-vault users
+
+## Scope Boundaries
+
+- No new external Python dependencies
+- Permission model remains advisory (skill instructions, not filesystem ACLs)
+- Vault file format unchanged (markdown + YAML frontmatter)
+- No changes to `vault-architect` scripts (`analyze_vault.py`, `validate_frontmatter.py`) — these already return JSON and do not write vault files
+
+### Deferred to Separate Tasks
+
+- **Git-based vault momentum metrics** (`_vault-profile.md` activity signals): separate issue, requires git CLI integration
+- **Move behavioral policies from script docstrings to `references/`**: lower priority once thresholds are externalized via CLI args
+- **Canvas/Bases file update-and-refresh workflows**: separate task after primitives refactor lands
+- **Property schema creation** (currently only updates existing properties): scope/design needs its own issue
+- **#113 canvas layout gaps** (frontmatter grouping, edge labels, color mapping): addressed in Unit 6 for the layout portion; full #113 closure deferred pending canvas primitives
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `plugins/archivist/agents/archivist.md` — Initialization, workflow orchestration, bounded autonomy, scripts table
+- `plugins/archivist/skills/vault-curator/scripts/generate_canvas.py` — Writes `.canvas` file directly; has `--dry-run` mode that returns JSON but skips write; hardcoded `NODE_WIDTH=300`, `max_nodes=50`
+- `plugins/archivist/skills/vault-curator/scripts/merge_notes.py` — Writes merged target note directly; `--dry-run` returns JSON diff
+- `plugins/archivist/skills/vault-curator/scripts/redirect_links.py` — Edits all matching vault files directly; `--dry-run` returns affected-file list
+- `plugins/archivist/skills/vault-curator/scripts/find_similar_notes.py` — Already accepts `--min-similarity` as CLI arg (good pattern to follow)
+- `plugins/archivist/skills/vault-curator/scripts/check_collection_health.py` — Returns JSON; `BASES_DIR = "900 📐Templates/970 Bases"` hardcoded; coverage threshold hardcoded in detection logic
+- `plugins/archivist/commands/` — Six commands exist: canvas, collection, drift, duplicates, health, vault. `help.md` and `workflows.md` are missing.
+- `plugins/archivist/.local.md.example` — Single-vault format; no named-profile support yet
+
+### Institutional Learnings
+
+- The `--dry-run` pattern already in all three target scripts is the right primitives entry point: extend it so normal (non-dry-run) mode also returns JSON without writing — writing becomes the caller's responsibility
+- `find_similar_notes.py` already exposes `--min-similarity` — use it as the template for how to add CLI args to other scripts
+- The existing `Bounded Autonomy` zone model in `archivist.md` already handles "agent controls writes" — the primitives refactor closes the gap where scripts bypass this by writing directly
+
+### External References
+
+- [Obsidian JSON Canvas spec](https://jsoncanvas.org/) — Node types, edge schema, group node semantics (relevant to Unit 6)
+- Issue #113 — canvas generation gaps (frontmatter grouping, layout, color mapping) — partially addressed in Unit 6
+
+## Key Technical Decisions
+
+- **Primitives via flag, not architecture change**: Add `--no-write` flag to `generate_canvas.py`, `merge_notes.py`, `redirect_links.py`. When set, return JSON and skip all file I/O. This is backward-compatible and testable. The agent's workflows change from calling scripts that write to calling scripts with `--no-write`, receiving JSON, then using the Write/Edit tool.
+- **`merge_notes.py --no-write`**: Returns proposed target note content as a JSON field alongside the existing `frontmatter_changes` structure. Agent writes the target file with Write/Edit tool.
+- **`redirect_links.py --no-write`**: Returns `{affected_files: [{path, content_after}]}`. Agent applies edits. For large vaults (many affected files) this could be heavy — cap at 50 affected files and warn; bulk cases fall back to script-controlled writes with explicit user approval.
+- **Index refresh step**: `bash obsidian vault` is a read-only command that verifies connection. The actual trigger is `bash obsidian` CLI operations. After any Write/Edit tool write to the vault, add a follow-up `bash obsidian search query="<written-note-title>"` to force Obsidian to index the change (or simply document that users may need to wait 1–5s for backlinks).
+- **Multi-vault `.local.md`**: Use a named-profile YAML structure (`vaults:` map) while keeping the legacy flat `vault_path:` key readable. Init selects by matching against `$PWD` or the first defined vault if unambiguous.
+- **Delete workflows**: No new Python scripts needed. Deletes are handled by the agent using `bash rm` (for files in `designated_output_zones`) or `bash obsidian` delete commands, always preceded by a link-redirect dry-run to surface downstream impact.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should `redirect_links.py --no-write` return full file content?** Yes for correctness, but cap at 50 files to avoid memory issues. Beyond cap, fall back to script-controlled writes with user approval.
+- **Does `obsidian vault` trigger indexing?** No — it's a read-only health check. Real index trigger is any write via `obsidian create`/`obsidian append`. After agent Write tool calls, index refresh requires a follow-up `obsidian` command or explicit wait instruction.
+- **#113 scope in this plan?** Partially: Unit 6 addresses layout improvements (node grouping by fileClass, edge direction labels). Full #113 closure (Chronos integration, edge type vocabulary) is deferred.
+
+### Deferred to Implementation
+
+- Exact YAML structure for multi-vault `.local.md`: implement the simplest viable format that doesn't break single-vault users; refine based on real usage
+- Whether `redirect_links.py --no-write` should embed full file content or just diff hunks: start with full content, optimize if context window pressure appears
+
+## Output Structure
+
+```
+plugins/archivist/
+├── agents/
+│   └── archivist.md                      (modified — init enrichment, workflow refresh hints, delete workflows)
+├── commands/
+│   ├── help.md                           (new — capability discovery)
+│   └── workflows.md                      (new — /workflows action parity)
+├── skills/
+│   ├── vault-architect/
+│   │   └── references/
+│   │       ├── vault-analysis-checks.md         (new — documents analyze_vault.py checks)
+│   │       └── frontmatter-schema-reference.md  (new — documents validate_frontmatter.py fields)
+│   └── vault-curator/
+│       ├── references/
+│       │   └── collection-health-criteria.md    (new — documents check_collection_health.py criteria)
+│       └── scripts/
+│           ├── generate_canvas.py        (modified — --no-write flag, --node-width, --node-height, fileClass grouping)
+│           ├── merge_notes.py            (modified — --no-write flag)
+│           ├── redirect_links.py         (modified — --no-write flag, 50-file cap)
+│           └── check_collection_health.py (modified — --coverage-threshold flag)
+└── .local.md.example                     (modified — named-vault profile format)
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Prompt-Native Reference Files**
+
+**Goal:** Move code-native policy knowledge out of script docstrings and into loadable markdown references so the agent can cite them and users can understand the rules.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Create: `plugins/archivist/skills/vault-curator/references/collection-health-criteria.md`
+- Create: `plugins/archivist/skills/vault-architect/references/vault-analysis-checks.md`
+- Create: `plugins/archivist/skills/vault-architect/references/frontmatter-schema-reference.md`
+
+**Approach:**
+- `collection-health-criteria.md` (vault-curator): document what makes a collection "healthy" vs "partial" vs "missing_infrastructure"; explain the 60% fileClass coverage threshold; define the 5 required parts (folder, folder note, Bases embed, Bases file, template); explain detection heuristic (folder note OR ≥5 notes with ≥60% fileClass coverage)
+- `vault-analysis-checks.md` (vault-architect): document each check `analyze_vault.py` runs (orphan detection, untagged notes, inconsistent frontmatter, duplicate titles, missing temporal links); define what "orphan" means (no incoming wikilinks); describe output field meanings
+- `frontmatter-schema-reference.md` (vault-architect): document the fields `validate_frontmatter.py` checks; severity levels; common violations and remediation
+- Add `Load when:` annotations at the top of each file so the agent knows when to pull them in
+
+**Test scenarios:**
+- Test expectation: none — pure documentation files, no executable behavior change
+
+**Verification:**
+- All three files exist and are non-empty
+- Each file's `Load when:` annotation matches the triggering workflow in `archivist.md`
+- `check_collection_health.py` docstring's field descriptions match `collection-health-criteria.md`
+
+---
+
+- [ ] **Unit 2: Context Injection — Enriched Initialization**
+
+**Goal:** Surface actionable vault signals (orphan count, schema drift indicators, unhealthy collections) at session start before the user asks, so the agent can lead with the highest-priority issue.
+
+**Requirements:** R4
+
+**Dependencies:** None (pure `archivist.md` change; Units 1 references loaded when needed)
+
+**Files:**
+- Modify: `plugins/archivist/agents/archivist.md` — Initialization section (step 4 or new step 5)
+
+**Approach:**
+- After the existing 4 init steps, add a "Quick Vault Signals" pass:
+  - Run `obsidian orphans | wc -l` to get orphan count
+  - Run `check_collection_health.py --dry-run` to get candidate folder list; then run `check_collection_health.py` (no `--dry-run`) scoped to each candidate folder to get actual health status; flag any folder returning `health: partial` or `health: missing_infrastructure`
+  - Do NOT run full `analyze_vault.py` at init — too slow; reserve for `/health` command
+- Store results in session state and use them to prime the opening prompt:
+  - If orphan count > 20: surface as issue #1
+  - If unhealthy collections found: surface as issue #2
+  - If no issues: open with "Vault looks healthy — what would you like to work on?"
+- Add a note that `references/collection-health-criteria.md` explains health thresholds
+
+**Test scenarios:**
+- Happy path: vault with no issues → agent reports "Vault looks healthy"
+- Edge case: `obsidian orphans` unavailable (CLI not running) → agent falls back to skipping orphan count, continues without signal
+- Edge case: vault with 0 collections → health check returns empty list, no error
+- Integration: unhealthy collection detected at init → agent mentions it as a suggested workflow before user speaks
+
+**Verification:**
+- Init completes without requiring user input for vaults with `.local.md` configured
+- Agent's opening message references specific signals (orphan count, unhealthy collection names) rather than generic greetings
+- If CLI unavailable, init still completes (no hard failure)
+
+---
+
+- [ ] **Unit 3: UI Integration — Obsidian Index Refresh**
+
+**Goal:** After any agent-controlled write to the vault, trigger Obsidian's indexer so backlinks and graph data are current within seconds rather than minutes.
+
+**Requirements:** R3
+
+**Dependencies:** Unit 6 (primitives refactor) — the write step moves from scripts to the agent; this unit updates `archivist.md` workflow steps that include agent Write/Edit calls. Can be applied before Unit 6 to script-write workflows and re-applied after Unit 6 to agent-write workflows.
+
+**Files:**
+- Modify: `plugins/archivist/agents/archivist.md` — Visualization: Canvas Map Generation workflow; Consolidation: Merge Notes workflow; Consolidation: Redirect Links workflow
+
+**Approach:**
+- After each step that writes a vault file (whether via script or agent Write tool), add: `bash obsidian search query="<written-note-title>" format=json limit=1` — intended to prompt Obsidian to recheck its index
+- Document the refresh step with a comment: `# Trigger Obsidian index refresh — resolves backlink latency after write`
+- **NOTE (implementation-time verification required):** Confirm whether `obsidian search` actually triggers a fresh index pass or reads the existing stale index. If it reads stale, replace with an explicit wait instruction: `# Obsidian may take 1–5s to index new files; backlinks will resolve shortly`
+- If `obsidian` CLI is unavailable (Obsidian not running), the search fails silently — document that fallback: `# If CLI unavailable, backlinks may take up to 30s to appear`
+- For canvas writes: use the canvas filename stem as the search query
+
+**Test scenarios:**
+- Happy path: after writing a note, search returns the note within 2s
+- Edge case: Obsidian not running → search fails; agent continues without error
+- Integration: after merge + redirect, backlinks from redirected notes resolve to new target within the same session
+
+**Verification:**
+- Every `archivist.md` workflow step that writes a file has a follow-up index refresh command
+- No workflow step writes and then immediately reads backlinks without a refresh call between
+
+---
+
+- [ ] **Unit 4: Action Parity + Capability Discovery — Commands**
+
+**Goal:** Add the two missing command files to close the capability discovery gap and expose the Known Workflows table as a slash command.
+
+**Requirements:** R5, R6
+
+**Dependencies:** None
+
+**Files:**
+- Create: `plugins/archivist/commands/help.md`
+- Create: `plugins/archivist/commands/workflows.md`
+
+**Approach:**
+- `commands/help.md`: Invoke the archivist agent to list all available slash commands with a one-line description of each. Agent should: read its own `commands/` directory (Glob `${CLAUDE_PLUGIN_ROOT}/commands/*.md`), read each command's `description` frontmatter field, and present a formatted table. Include a note pointing to `skills/vault-*/SKILL.md` for deeper capability docs.
+- `commands/workflows.md`: Invoke the archivist agent to: (1) read `_vault-profile.md` from the vault, (2) extract the `## Known Workflows` table and `## Workflow Candidates` table, (3) present both to the user. If `_vault-profile.md` is absent, surface that as the issue and offer to run vault profiling.
+- Both commands follow the existing command file convention: `name` + `description` frontmatter, then prose instructions for the agent.
+
+**Test scenarios:**
+- Happy path: `/help` produces a table of all 8 commands (canvas, collection, drift, duplicates, health, vault, workflows, help)
+- Happy path: `/workflows` loads `_vault-profile.md` and presents both tables
+- Edge case: `/workflows` called before vault profiling (no `_vault-profile.md`) → agent explains and offers profiling
+- Edge case: `_vault-profile.md` exists but has no workflow tables yet → agent reports empty tables, offers to run workflows to populate
+
+**Verification:**
+- `commands/help.md` and `commands/workflows.md` exist with valid frontmatter
+- `help.md` produces output listing all 8 commands when invoked
+- `workflows.md` reads from `_vault-profile.md` and presents both tables without running any Python scripts
+
+---
+
+- [ ] **Unit 5: Prompt-Native — Externalize Hardcoded Thresholds**
+
+**Goal:** Move hardcoded numeric constants in Python scripts to CLI args with documented defaults, making them overridable without code changes.
+
+**Requirements:** R1, R8
+
+**Dependencies:** None (independent of Unit 7)
+
+**Files:**
+- Modify: `plugins/archivist/skills/vault-curator/scripts/generate_canvas.py` — add `--node-width`, `--node-height`; document existing `--max-nodes` in archivist.md table
+- Modify: `plugins/archivist/skills/vault-curator/scripts/check_collection_health.py` — add `--coverage-threshold` (currently hardcoded via detection heuristic)
+- Modify: `plugins/archivist/agents/archivist.md` — Scripts table: document new args; Collection Health Check workflow: note coverage threshold override
+
+**Approach:**
+- `generate_canvas.py`: `--max-nodes` already accepted; add `--node-width <px>` (default 300) and `--node-height <px>` (default 120). Constants `NODE_WIDTH`, `NODE_HEIGHT` become CLI args fed to layout and generation functions.
+- `check_collection_health.py`: add `--coverage-threshold <pct>` (default 60). The detection condition `≥60% share a fileClass` reads this value from args.
+- `find_similar_notes.py`: already has `--min-similarity` — no change needed, just document it in `collection-health-criteria.md` reference
+- Do NOT expose `NODE_SPACING_X`, `NODE_SPACING_Y`, `GROUP_PADDING`, `GROUP_LABEL_HEIGHT` — these are layout internals, not user-facing policy thresholds
+- Update `archivist.md` Scripts table to include the new args
+
+**Test scenarios:**
+- Happy path: `generate_canvas.py --node-width 400` produces nodes with width=400 in output JSON
+- Happy path: `check_collection_health.py --coverage-threshold 80` flags collections that would be "healthy" at 60% but not at 80%
+- Edge case: `--coverage-threshold 0` → all folders qualify; script should not error, but output will be large
+- Edge case: `--node-width 0` → invalid; script should return JSON error `{"status": "error", "error": "node-width must be > 0"}`
+
+**Verification:**
+- `generate_canvas.py --help` (or running without args) documents `--node-width` and `--node-height`
+- `check_collection_health.py --coverage-threshold 80` returns different results than at 60% for a vault with partially-covered collections
+- All new args have default values matching the previous hardcoded constants (no behavior change when args omitted)
+
+---
+
+- [ ] **Unit 6a: Tools as Primitives — Script Primitive Refactor**
+
+**Goal:** Refactor `generate_canvas.py`, `merge_notes.py`, and `redirect_links.py` so they never write files — they compute and return structured JSON. The agent controls the write decision.
+
+**Requirements:** R7
+
+**Dependencies:** Unit 5 (threshold args in place before this refactor to avoid two passes on the same scripts)
+
+**Files:**
+- Modify: `plugins/archivist/skills/vault-curator/scripts/generate_canvas.py` — add `--no-write` flag
+- Modify: `plugins/archivist/skills/vault-curator/scripts/merge_notes.py` — add `--no-write` flag; return proposed target content in JSON
+- Modify: `plugins/archivist/skills/vault-curator/scripts/redirect_links.py` — add `--no-write` flag; return `{affected_files: [{path, content_after}]}` capped at 50 files
+- Modify: `plugins/archivist/agents/archivist.md` — update Canvas Map Generation, Merge Notes, and Redirect Links workflows to use `--no-write`, receive JSON, then use Write/Edit tool
+
+**Approach:**
+
+*generate_canvas.py `--no-write`:*
+- Current non-dry-run: computes canvas data → writes `.canvas` file → prints result JSON
+- With `--no-write`: computes canvas data → prints full result JSON under a `canvas_data` key → does not write
+- Result shape: `{"status": "success", "canvas_path": "...(suggested)", "canvas_data": {...nodes, edges...}, "nodes": N, "edges": M, "clusters": [...], "total_notes_scanned": K}`
+- Agent receives this, reviews `canvas_data`, then uses Write tool to write `<scope>/<output_name>.canvas` with `json.dumps(canvas_data)`
+
+*merge_notes.py `--no-write`:*
+- Current non-dry-run: computes merged frontmatter + appended content → writes target file → prints result JSON
+- With `--no-write`: computes merged result → returns `{"status": "success", ..., "target_content": "<full merged markdown string>"}` → does not write
+- Conflict resolution workflow: (1) call `--dry-run` to get conflict list; (2) present conflicts to user; (3) call `--no-write` to get `target_content`; (4) agent applies user resolutions to `target_content` string; (5) agent writes resolved content with Write tool
+- Dry-run remains unchanged (still used for initial conflict preview)
+
+*redirect_links.py `--no-write`:*
+- Current non-dry-run: scans all vault files → applies regex replacements in place → prints summary
+- With `--no-write`: scans and computes replacements → returns `{"affected_files": [{"path": "...", "content_after": "..."}], "total_replacements": N}` capped at 50 files; if >50 affected files, returns `{"status": "too_many", "affected_count": N, "message": "Too many files to return inline. Use script-controlled mode (omit --no-write) with explicit approval."}` → does not write
+- Agent iterates `affected_files`, applies each with Edit tool; for the >50 cap case, agent obtains explicit user confirmation then calls script without `--no-write`
+
+*archivist.md workflow updates:*
+- Canvas: call with `--no-write`, receive JSON, write canvas file with Write tool, run index refresh
+- Merge: call dry-run for conflict preview, resolve conflicts agent-side, call with `--no-write`, write target with Write tool, run index refresh
+- Redirect: call with `--no-write`, apply edits with Edit tool per file (or fall back for large sets), run index refresh
+
+**Patterns to follow:**
+- `--dry-run` in all three scripts (existing pattern) — `--no-write` follows the same flag convention
+- `find_similar_notes.py` dry-run behavior — always returns JSON, never writes
+
+**Test scenarios:**
+- Happy path: `generate_canvas.py --no-write --scope "700 Notes"` returns JSON with `canvas_data` key and no file written
+- Happy path: `merge_notes.py --no-write --source A.md --target B.md` returns `target_content` string with merged frontmatter + content
+- Happy path: `redirect_links.py --no-write --old A --new B` returns `affected_files` list with `content_after` for each
+- Edge case: redirect with >50 affected files → returns `status: too_many` with count; agent falls back to script-controlled mode
+- Edge case: `generate_canvas.py --no-write` on empty scope → returns `total_notes: 0` with empty canvas_data
+- Integration: full canvas workflow (agent calls `--no-write`, receives JSON, writes `.canvas` file with Write tool, runs index refresh) produces a valid readable canvas in Obsidian
+- Integration: full merge workflow (dry-run → conflict resolution → `--no-write` → agent reconstructs resolved content → Write tool) produces correct merged note
+- Error path: script error (e.g., vault path invalid) → returns `{"status": "error", "error": "..."}` same as before
+
+**Verification:**
+- All three scripts with `--no-write` produce zero file writes during execution
+- `archivist.md` workflows no longer have steps that say "Execute (remove --dry-run)" — instead they say "Apply JSON result with Write/Edit tool"
+- Canvas files written by the agent via Write tool are valid JSON Canvas spec format and open in Obsidian without error
+
+---
+
+- [ ] **Unit 6b: Canvas Quality — FileClass Grouping + Edge Labels**
+
+**Goal:** Improve canvas layout quality by grouping nodes by `file_class` into named group nodes (beyond folder clustering) and making link direction visible via edge labels.
+
+**Requirements:** partial R1 (canvas layout policy now documentable); partial closure of #113
+
+**Dependencies:** Unit 6a (`generate_canvas.py` is already being modified; do this in the same or immediately following pass to avoid a third touch)
+
+**Files:**
+- Modify: `plugins/archivist/skills/vault-curator/scripts/generate_canvas.py` — add fileClass group node layout; add edge direction markers; expand `fileclass_color()` mapping
+
+**Approach:**
+- After clustering by folder, group notes by `file_class` into named group nodes (JSON Canvas `type: "group"` nodes). Group nodes are labeled with the fileClass name and contain all member node IDs.
+- Add `"fromEnd": "arrow"` (or `"label": "→"`) on edges to make link direction visible in Obsidian's canvas view
+- Expand `fileclass_color()` mapping with additional entries: `workflow`, `capture`, `template` (map to appropriate preset colors from the existing scheme)
+- Document the grouping strategy in `vault-curator/references/collection-health-criteria.md` (or a new canvas layout reference if it grows large enough)
+
+**Patterns to follow:**
+- Existing `fileclass_color()` function and color preset scheme in `generate_canvas.py`
+- JSON Canvas spec group node schema at jsoncanvas.org
+
+**Test scenarios:**
+- Happy path: canvas with mixed fileClasses produces group nodes labeled by fileClass
+- Happy path: edges have direction markers visible in Obsidian canvas view
+- Edge case: notes with no `file_class` frontmatter → placed in an "Uncategorized" group or left ungrouped (implementer decision)
+- Edge case: single-member fileClass group → still rendered as a group node (consistent presentation)
+- Regression: existing canvas output fields (`clusters`, `total_notes_scanned`, `nodes`, `edges`) unchanged
+
+**Verification:**
+- `generate_canvas.py` output includes `type: "group"` nodes when fileClass data is present
+- Edges include direction markers
+- `fileclass_color()` handles `workflow`, `capture`, `template` without falling through to default
+
+---
+
+- [ ] **Unit 7: CRUD — Delete Workflows**
+
+**Goal:** Add explicit delete workflows for vault infrastructure (templates, Bases files, canvas files) so users have a clean path to remove cruft without the agent refusing or improvising.
+
+**Requirements:** R9
+
+**Dependencies:** Unit 3 (UI integration — index refresh after delete)
+
+**Files:**
+- Modify: `plugins/archivist/agents/archivist.md` — add Delete Workflows section under Workflow Orchestration
+
+**Approach:**
+- Add three named workflows in `archivist.md`:
+  - **Delete Template**: check for references to the template (Glob `*.md` for `[[TemplateName]]`); present impacted notes; confirm; delete using `bash rm "${VAULT_PATH}/<template-path>"`; run index refresh
+  - **Delete Bases File**: check for `![[BaseName.base]]` embeds in folder notes; present impacted folder notes; confirm; delete `.base` file; offer to remove embed from folder notes (separate confirmation); run index refresh
+  - **Delete Canvas**: canvas files have no dependents (they're outputs, not sources); confirm once; delete; run index refresh
+- All deletes: require explicit confirmation, log the deletion in session notes, never delete without a dependency check first
+- Use `bash rm` only for files in `designated_output_zones` (generated, no confirmation-extra needed); for structural zones (templates, bases), require a pre-delete impact check
+- Add to `archivist.md` Bounded Autonomy table: Delete is always a structural-zone operation requiring confirmation regardless of zone
+
+**Test scenarios:**
+- Happy path: delete canvas file → no dependency check needed → single confirmation → file removed
+- Happy path: delete template → agent finds 3 notes using it → presents them → user confirms → template deleted
+- Error path: delete Bases file that is embedded in 10 folder notes → agent lists all 10, requires per-operation confirmation, does not proceed without it
+- Edge case: template has no references → agent confirms "No notes reference this template" → proceeds after confirmation
+- Edge case: file to delete does not exist → agent reports gracefully, no error crash
+
+**Verification:**
+- Delete workflows are listed in the `archivist.md` Workflow Orchestration section
+- Each delete workflow includes: dependency check → impact presentation → confirmation → delete → index refresh
+- No delete workflow omits the dependency check step
+
+---
+
+- [ ] **Unit 8: Shared Workspace — Multi-Vault `.local.md`**
+
+**Goal:** Allow `.local.md` to store named vault profiles so users with multiple Obsidian vaults can switch contexts without manually editing the config file.
+
+**Requirements:** R10
+
+**Dependencies:** Unit 2 (init enrichment uses `.local.md`)
+
+**Files:**
+- Modify: `plugins/archivist/.local.md.example` — add named-vault YAML structure
+- Modify: `plugins/archivist/agents/archivist.md` — Initialization step 2: add multi-vault detection and selection logic
+
+**Approach:**
+- `.local.md` new format (backward-compatible): keep flat `vault_path:` as a legacy fallback; add optional `vaults:` map where each key is a vault name and value includes `path:`, optional `architect_write_zones:`, `curator_write_zones:`, `designated_output_zones:`
+- Init logic: if `vaults:` key present with 2+ entries, check `$PWD` against each vault's `path:`; if $PWD is inside a vault path, auto-select it. If ambiguous (PWD not inside any vault), present named choices via `AskUserQuestion`.
+- If only one vault defined (or legacy `vault_path:` format), no selection needed — existing behavior unchanged
+- Update `.local.md.example` with a commented-out `vaults:` block showing two named vaults alongside the legacy `vault_path:` format
+
+**Patterns to follow:**
+- Current `.local.md.example` for field naming conventions
+- Current init step 2 in `archivist.md` for the read/parse/prompt flow
+
+**Test scenarios:**
+- Happy path: single `vault_path:` → auto-selected, no prompt (existing behavior preserved)
+- Happy path: two vaults defined, $PWD inside vault A → vault A auto-selected
+- Happy path: two vaults defined, $PWD not in either → AskUserQuestion presents vault names, user picks one
+- Edge case: `vaults:` defined with one entry → auto-selected without prompt
+- Edge case: vault path in `vaults:` uses `~` → expansion handled correctly
+- Edge case: `.local.md` has both `vault_path:` (legacy) and `vaults:` → `vaults:` takes precedence, warn user about redundancy
+
+**Verification:**
+- `.local.md.example` shows both legacy and new format with clear comments explaining the difference
+- Init step 2 in `archivist.md` documents multi-vault selection logic
+- Single-vault users experience no change in init behavior
+
+## System-Wide Impact
+
+- **Interaction graph:** All three refactored scripts (`generate_canvas.py`, `merge_notes.py`, `redirect_links.py`) are called from `archivist.md` workflows — those workflow steps must be updated in the same commit as the `--no-write` flag addition to avoid a broken intermediate state
+- **Error propagation:** Scripts returning `{"status": "error", ...}` — agent must handle these before calling Write tool (don't write if script errored)
+- **State lifecycle risks:** `redirect_links.py` in `--no-write` mode returns `content_after` for up to 50 files. Agent must apply all edits or none (git checkpoint before link redirect remains in the workflow)
+- **API surface parity:** The `--dry-run` flag behavior is unchanged; `--no-write` is additive. Existing callers using `--dry-run` continue to work.
+- **Integration coverage:** Canvas write-then-read-backlinks scenario requires Unit 3 (index refresh) to be in place alongside Unit 6a (primitives) to avoid stale-backlink issues in the same session
+- **Unchanged invariants:** `analyze_vault.py` and `validate_frontmatter.py` already return JSON and do not write files — they are not touched. The existing `--dry-run` behavior on all scripts is preserved unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `redirect_links.py --no-write` returns large payloads for heavily-linked notes | 50-file cap with fallback to script-controlled mode; cap is explicit in the API contract |
+| Init enrichment (Unit 2) adds latency to session start | Run `obsidian orphans \| wc -l` only (not full list); use `check_collection_health.py --dry-run` (candidate scan, not full health check); skip if CLI unavailable |
+| Multi-vault `.local.md` change breaks existing single-vault setups | Legacy `vault_path:` key is preserved; new `vaults:` key is additive and optional |
+| `--no-write` flag changes the caller contract for `generate_canvas.py` | `--dry-run` (preview only) and `--no-write` (full compute, no write) are clearly distinct; `archivist.md` workflows updated atomically with Unit 6a |
+| Canvas quality improvements (fileClass grouping) change output format | JSON Canvas spec allows group nodes — grouping is additive; existing canvases are not modified; isolated in Unit 6b so it can be skipped without affecting primitives |
+| Deleting a template that is referenced by an active Templater QuickAdd macro | Dependency check scans wikilinks but not plugin config JSON; document this limitation in the delete workflow |
+
+## Documentation / Operational Notes
+
+- `SKILL.md` for `vault-curator` should reference the new `references/collection-health-criteria.md` and `references/vault-analysis-checks.md` files in its Collection Health Check section
+- Run `uv run plugins/skillsmith/skills/skillsmith/scripts/evaluate_skill.py` on both `SKILL.md` files and on `archivist.md` after each unit that modifies them; record scores in `README.md` version history
+- The `archivist.md` agent file does not go through skillsmith evaluation (it's an agent, not a skill), but its version history entry in `README.md` should note which audit principles improved
+
+## Sources & References
+
+- **Related issue:** [#160](https://github.com/totallyGreg/claude-mp/issues/160) — agent-native architecture audit (source of all improvements)
+- **Related issue:** [#113](https://github.com/totallyGreg/claude-mp/issues/113) — canvas generation gaps (partially addressed in Unit 6)
+- **Existing archivist plan:** `plugins/archivist/docs/plans/2026-03-31-001-feat-archivist-permissions-vault-state-commands-plan.md` (completed — context for where we started)
+- Related code: `plugins/archivist/agents/archivist.md` (init, workflows)
+- Related code: `plugins/archivist/skills/vault-curator/scripts/generate_canvas.py` (primitives refactor target)
+- Related code: `plugins/archivist/skills/vault-curator/scripts/find_similar_notes.py` (CLI arg pattern to follow)
+- External: [JSON Canvas spec](https://jsoncanvas.org/) (canvas node/edge schema)

--- a/plugins/archivist/skills/vault-architect/SKILL.md
+++ b/plugins/archivist/skills/vault-architect/SKILL.md
@@ -74,6 +74,9 @@ When asked to analyze a vault or suggest improvements:
 2. **Analyze for Issues** - Use `scripts/analyze_vault.py` to find untagged notes, orphans, inconsistent frontmatter, duplicate titles, missing temporal links
 3. **Provide Actionable Recommendations** - Suggest frontmatter improvements, Bases queries, template consolidation, folder refinements
 
+**References:**
+- `references/vault-analysis-checks.md` - Each check's detection logic, output fields, interpretation, and remediation
+
 ### 2. Template Creation with Templater
 
 Create templates that prompt for input, rename/move files automatically, set frontmatter, embed Bases views, and position the cursor.
@@ -102,6 +105,7 @@ Validate schemas with `scripts/validate_frontmatter.py`. Document conventions in
 
 **References:**
 - `references/excalibrain-metadata.md` - Complete semantic field documentation
+- `references/frontmatter-schema-reference.md` - Fields checked by validate_frontmatter.py, severity levels, canonical field names, common violations
 
 ### 5. Timeline Visualization with Chronos
 

--- a/plugins/archivist/skills/vault-architect/references/frontmatter-schema-reference.md
+++ b/plugins/archivist/skills/vault-architect/references/frontmatter-schema-reference.md
@@ -1,0 +1,154 @@
+---
+name: Frontmatter Schema Reference
+description: Documents fields and rules checked by validate_frontmatter.py — field types, severity levels, common violations, and remediation
+load_when: Running frontmatter validation, interpreting validate_frontmatter.py output, designing new note schemas
+---
+
+# Frontmatter Schema Reference
+
+**Load when:** Running the `/health` command, interpreting `validate_frontmatter.py` output, or designing frontmatter schemas for new note types.
+
+## Overview
+
+`validate_frontmatter.py` validates frontmatter in vault notes. Two operating modes:
+
+- **Schema generation** (`--generate-schema`): Infers field types and usage percentages from existing notes; outputs a schema JSON file
+- **Validation** (`--schema FILE`): Validates all notes against a provided schema JSON
+
+Skips files with "Template" in the path and files starting with `_`. Only processes notes that have YAML frontmatter (delimited by `---`).
+
+---
+
+## Checks Performed
+
+### Missing Required Fields
+
+**Triggered by:** `--required <field1,field2,...>`
+
+**What it checks:** Whether each note contains all explicitly required fields.
+
+**Output field:** `missing_required` — list of `{note, missing: [fields]}` objects.
+
+**Severity:** High — these fields are declared mandatory by the operator.
+
+**Remediation:** Use `suggest_properties.py` to populate missing fields from peer analysis, or apply manually per note.
+
+---
+
+### Type Mismatches
+
+**Triggered by:** `--schema FILE` when the schema declares field types.
+
+**What it checks:** Whether each field's Python runtime type matches the schema-declared type.
+
+**Type names used:** Python `type.__name__` values — `str`, `int`, `float`, `bool`, `list`, `NoneType`.
+
+**Output field:** `type_mismatch` — list of `{note, field, expected, actual, value}` objects.
+
+**Severity:** Medium — type mismatches break Bases queries and Metadata Menu plugin behavior.
+
+**Common cause:** Dates stored as integers (`20260101`) instead of ISO strings (`"2026-01-01"`).
+
+**Remediation:** Correct the field value in frontmatter. Obsidian Linter can enforce date string formats.
+
+---
+
+### Empty Values
+
+**Always checked.**
+
+**What it checks:** Fields present in frontmatter with value `''` (empty string) or `null`/`None`.
+
+**Output field:** `empty_values` — list of `{note, field}` objects, summarized by field with counts.
+
+**Severity:** Low — empty fields add noise to Bases views and may indicate incomplete captures.
+
+**Remediation:** Populate the field or remove it from frontmatter if not applicable to this note type.
+
+---
+
+### Inconsistent Date Formats
+
+**Always checked.**
+
+**What it checks:** Fields with date-semantic names that don't start with `YYYY-MM-DD`.
+
+**Fields checked:** `date`, `date created`, `date modified`, `created`, `modified`.
+
+**Output field:** `inconsistent_dates` — list of `{note, field, value}` objects.
+
+**Severity:** Medium — non-ISO dates break Bases date sorting and Chronos timeline integration.
+
+**Remediation:** Standardize to `YYYY-MM-DD`. Obsidian Linter can automate date format normalization vault-wide.
+
+---
+
+### Duplicate Fields (Case Variations)
+
+**Always checked.**
+
+**What it checks:** Notes where the same logical field appears under multiple case variants (e.g., both `fileClass` and `fileclass` in the same note).
+
+**Output field:** `duplicate_fields` — list of `{note, fields: [variants]}` objects.
+
+**Severity:** High — YAML parsers typically keep only one variant; the other is silently discarded. Plugin behavior (Metadata Menu, Bases) depends on exact field name casing.
+
+**Remediation:** Remove the non-canonical variant. Use Obsidian Linter to enforce consistent casing.
+
+---
+
+## Schema Generation
+
+`--generate-schema` produces a schema JSON inferred from all notes:
+
+```json
+{
+  "fields": {
+    "fileClass": {
+      "type": "str",
+      "usage_count": 142,
+      "percentage": 87.1,
+      "examples": ["meeting", "project", "person"]
+    }
+  }
+}
+```
+
+Use this to bootstrap a schema file. Review it, trim low-usage fields, then pass it back via `--schema` for ongoing validation.
+
+---
+
+## Canonical Field Names
+
+These field names are used consistently across this vault:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `fileClass` | string | Note type (links to Metadata Menu fileClass definition) |
+| `tags` | list | Obsidian tags |
+| `created` | string | ISO 8601 creation date: `YYYY-MM-DD` |
+| `aliases` | list | Alternative names for wikilink resolution |
+| `title` | string | Display title when different from filename |
+
+**`fileClass` is the authoritative type field.** Variants `fileclass` and `FileClass` are non-canonical — flag them and normalize.
+
+---
+
+## Common Violations and Remediation
+
+| Violation | Cause | Fix |
+|-----------|-------|-----|
+| `fileclass` instead of `fileClass` | Manual edit or template typo | Rename key in frontmatter |
+| `created: 20260414` (integer) | Bare number without quotes | Change to `created: "2026-04-14"` |
+| `tags: meeting` (string instead of list) | Obsidian auto-conversion | Change to `tags: [meeting]` |
+| `aliases: []` (empty list) | Template placeholder not populated | Remove field or populate it |
+| `date: null` | Templater variable not resolved | Check Templater configuration |
+| Both `fileClass` and `fileclass` present | Copy-paste from different templates | Remove the non-canonical variant |
+
+---
+
+## Related Workflows
+
+- `/health` — Runs `validate_frontmatter.py` as part of the full health snapshot
+- `/drift` — Collection-scoped drift detection (complement to vault-wide validation)
+- `suggest_properties.py` — Suggests missing properties per note based on peer analysis

--- a/plugins/archivist/skills/vault-architect/references/vault-analysis-checks.md
+++ b/plugins/archivist/skills/vault-architect/references/vault-analysis-checks.md
@@ -1,0 +1,122 @@
+---
+name: Vault Analysis Checks
+description: Documents each check run by analyze_vault.py — what is detected, what output fields mean, and how to interpret results
+load_when: Running /health command, interpreting analyze_vault.py output, explaining vault issues to user
+---
+
+# Vault Analysis Checks
+
+**Load when:** Running the `/health` command or interpreting output from `analyze_vault.py`.
+
+## Overview
+
+`analyze_vault.py` runs structural checks on the vault and returns a JSON report (via `--json`). Five checks are available; all five run by default. Each check is independent and can be run individually with a flag.
+
+**Scope:** Skips files with "Template" in the path and files starting with `_`. Does not use `python-frontmatter` — uses a simple `key: value` line parser, so complex YAML may not parse correctly.
+
+---
+
+## Checks
+
+### 1. Untagged Notes (`--check-tags`)
+
+**What it detects:** Notes with no tags — neither a `tags:` frontmatter property nor any inline `#tag` in the body.
+
+**Output field:** `untagged` — list of vault-relative paths.
+
+**Interpretation:** Untagged notes are undiscoverable by tag-based views and harder to classify. Prioritize folders with heavy active use.
+
+**Remediation:** Use `suggest_properties.py` to suggest tags from content and peer notes.
+
+---
+
+### 2. Orphaned Notes (`--check-orphans`)
+
+**What it detects:** Notes with **no outgoing wikilinks AND no incoming wikilinks** — neither referenced by nor referencing other notes.
+
+**Definition of "orphan":** Both `links_out` (wikilinks the note contains) and `links_in` (wikilinks from other notes pointing here) are empty.
+
+**Output field:** `orphans` — list of vault-relative paths.
+
+**Interpretation:** Orphans are isolated from the knowledge graph. They won't appear in backlinks panes or graph views. Common causes: imported notes, stale drafts, capture-only notes never elaborated.
+
+**Remediation:** Run `find_related.py` on orphans to find link candidates. Consider adding to a MOC or deleting if truly stale.
+
+**Note on resolution:** Orphan detection matches by note `stem` (filename without extension). Two notes in different folders with the same stem are treated as the same link target — this is consistent with how Obsidian resolves unqualified wikilinks.
+
+---
+
+### 3. Frontmatter Consistency (`--check-frontmatter`)
+
+**What it detects:** Properties present in >50% of all notes but missing from at least one note.
+
+**Output fields:**
+- `common_fields` — list of field names used in >50% of notes
+- `missing_common_fields` — map of `{field: [paths of notes missing it]}`
+
+**Interpretation:** A field in >50% of notes is treated as a vault-level standard. Missing notes represent schema drift. This is a broad vault-wide check — for collection-scoped drift, use `detect_schema_drift.py`.
+
+**Remediation:** Use `suggest_properties.py` per note, or batch-apply via property update commands.
+
+---
+
+### 4. Temporal Links (`--check-temporal`)
+
+**What it detects:** Daily notes missing `Week:` or `Month:` frontmatter links.
+
+**Daily note identification:** A note is treated as daily if any of these are true:
+- `tags` frontmatter contains "daily" (case-insensitive)
+- Body contains `#daily`
+- Filename matches `YYYY-MM-DD` pattern
+
+**Output field:** `missing_temporal_links` — list of `{note, missing: ["Week", "Month"]}` objects.
+
+**Interpretation:** Temporal links connect daily notes to week/month rollup notes, enabling Chronos timeline views and period-based Bases filtering. Missing links break temporal navigation.
+
+**Remediation:** Use the Chronos workflow to generate rollup notes and backfill missing links.
+
+---
+
+### 5. Duplicate Titles (`--check-duplicates`)
+
+**What it detects:** Notes with identical or near-identical titles after stripping non-alphanumeric characters and lowercasing.
+
+**Output field:** `potential_duplicates` — map of `{normalized_title: [vault-relative paths]}`.
+
+**Interpretation:** "Potential" because normalization may over-match (e.g., "Project A" and "Project A (archived)" normalize differently, but "Daily Standup" and "DailyStandup" match). Treat as candidates requiring review.
+
+**Remediation:** Use `/duplicates` → `find_similar_notes.py` for semantic similarity confirmation, then the merge workflow to consolidate confirmed duplicates.
+
+---
+
+## Output Structure
+
+```json
+{
+  "untagged": ["path/to/note.md"],
+  "orphans": ["path/to/isolated.md"],
+  "common_fields": ["fileClass", "tags", "created"],
+  "missing_common_fields": {
+    "fileClass": ["path/note1.md", "path/note2.md"]
+  },
+  "missing_temporal_links": [
+    {"note": "2026-01-15.md", "missing": ["Week"]}
+  ],
+  "potential_duplicates": {
+    "projectmeeting": ["Projects/Meeting.md", "Notes/Project Meeting.md"]
+  }
+}
+```
+
+## Limitations
+
+- Orphan detection is name-based (stem), not path-based — consistent with Obsidian's wikilink resolution
+- Frontmatter parser is line-based (`key: value`), not full YAML — complex values (nested objects, multiline strings, quoted strings) may not parse correctly
+- Temporal link check only looks for `Week` and `Month` keys — other temporal fields (Quarter, Year) are not checked
+- This is a vault-wide structural check; for collection-level health, use `check_collection_health.py`
+
+## Related Commands
+
+- `/health` — Runs this script as part of a full health snapshot
+- `/duplicates` — Deeper duplicate analysis using semantic similarity
+- `/drift` — Collection-scoped schema drift detection

--- a/plugins/archivist/skills/vault-curator/SKILL.md
+++ b/plugins/archivist/skills/vault-curator/SKILL.md
@@ -290,6 +290,6 @@ uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/check_collection_healt
   ${VAULT_PATH} [--scope "${SCOPE}"] [--folder "700 Notes/Workflows"]
 ```
 
-Output fields: `has_folder_note`, `folder_note_embeds_bases`, `has_bases_file`, `dominant_fileclass`, `schema_drift_issues`, `health` — see `references/available-scripts.md` for field definitions.
+Output fields: `has_folder_note`, `folder_note_embeds_bases`, `has_bases_file`, `dominant_fileclass`, `schema_drift_issues`, `health` — see `references/collection-health-criteria.md` for field definitions, health thresholds, and fix priority order.
 
 **After report, offer fixes in order:** missing folder note or Bases file → scaffold via vault-architect; folder note missing Bases embed → add with confirmation; schema drift → run `detect_schema_drift.py --scope <folder>`.

--- a/plugins/archivist/skills/vault-curator/references/collection-health-criteria.md
+++ b/plugins/archivist/skills/vault-curator/references/collection-health-criteria.md
@@ -1,0 +1,102 @@
+---
+name: Collection Health Criteria
+description: Documents what makes an Obsidian collection healthy, partial, or missing infrastructure — used by check_collection_health.py
+load_when: Running collection health checks, scaffolding new collections, interpreting health check output
+---
+
+# Collection Health Criteria
+
+**Load when:** Running `/collection` workflow, `/health` command, or interpreting output from `check_collection_health.py`.
+
+## What is a Collection?
+
+A **Collection** is a vault folder containing notes of the same conceptual type, organized with standardized infrastructure:
+
+- A **folder note** at `<Folder>/<Folder>.md` — the collection's index and entry point
+- A **Bases file** at `900 📐Templates/970 Bases/<Name>.base` — the canonical query view for the collection
+- A **Bases embed** in the folder note: `![[<Name>.base#<View>]]` — connects the index to the query view
+- **Member notes** sharing a consistent `fileClass` frontmatter property
+
+## Candidate Detection
+
+A folder qualifies as a **candidate collection** if it meets either condition:
+
+1. **Has a folder note** — a file named the same as its parent folder (e.g., `700 Notes/Projects/Projects.md`)
+2. **Has density + fileClass coverage** — contains ≥5 notes where ≥60% share the same `fileClass` value (threshold overridable with `--coverage-threshold`)
+
+Folders are **excluded** from candidate detection if they:
+- Start with `.` (hidden folders, e.g., `.obsidian`)
+- Start with `_` (system folders)
+- Contain "Template" in the name
+- Contain 📐 emoji (infrastructure folders)
+
+## Health Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `healthy` | All three infrastructure pieces present; no schema drift |
+| `partial` | Infrastructure present but schema drift detected, OR exactly one infrastructure piece missing |
+| `missing_infrastructure` | Two or more infrastructure pieces absent |
+
+**Infrastructure pieces checked:**
+
+| Piece | Field | How checked |
+|-------|-------|-------------|
+| Folder note | `has_folder_note` | `<folder>/<Name>.md` exists |
+| Bases embed | `folder_note_embeds_bases` | Folder note body contains `![[*.base#...]]` |
+| Bases file | `has_bases_file` | `900 📐Templates/970 Bases/<Name>.base` exists |
+
+## Schema Drift Detection
+
+Schema drift is counted when a frontmatter property is present in ≥50% of member notes but missing from at least one. The `schema_drift_issues` field counts the number of such properties.
+
+Schema drift alone results in `partial` (not `missing_infrastructure`) when all three infrastructure pieces are present.
+
+## Output Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `folder` | string | Vault-relative path to the collection folder |
+| `name` | string | Folder name (last path component) |
+| `member_count` | int | Total `.md` files in the folder |
+| `has_folder_note` | bool | Whether `<Name>.md` exists inside the folder |
+| `folder_note_embeds_bases` | bool | Whether the folder note contains a `.base` embed |
+| `has_bases_file` | bool | Whether a `.base` file exists at the expected path |
+| `dominant_fileclass` | string\|null | Most common `fileClass` value among members |
+| `fileclass_coverage_pct` | float | % of non-folder-note members sharing the dominant fileClass |
+| `schema_drift_issues` | int | Number of properties present in ≥50% of notes but not all |
+| `health` | string | `healthy` \| `partial` \| `missing_infrastructure` |
+| `missing` | list | Infrastructure pieces absent: `folder_note`, `bases_embed`, `bases_file` |
+
+## CLI Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--scope <path>` | entire vault | Vault-relative folder to limit the scan |
+| `--folder <path>` | all candidates | Check a single specific folder |
+| `--dry-run` | false | Show candidate folders without running health checks |
+| `--coverage-threshold <pct>` | 60 | Minimum fileClass coverage % for density-based candidate detection |
+
+## Thresholds
+
+| Threshold | Default | Overridable |
+|-----------|---------|-------------|
+| Minimum notes for density detection | 5 | No |
+| fileClass coverage for density detection | 60% | Yes (`--coverage-threshold`) |
+| Schema drift: property presence threshold | 50% | No |
+| Bases file location | `900 📐Templates/970 Bases/` | No |
+
+## Fix Priority
+
+When collections are unhealthy, offer fixes in this order:
+
+1. `missing: folder_note` → scaffold via Collection Setup workflow
+2. `missing: bases_embed` → add `![[<Name>.base#<View>]]` embed to folder note (confirm first)
+3. `missing: bases_file` → scaffold via Collection Setup workflow
+4. `schema_drift_issues > 0` → run `detect_schema_drift.py --scope <folder>` and offer bulk property fixes
+
+## Related Workflows
+
+- [[collection]] — Full collection scaffolding workflow
+- [[health]] — Vault health snapshot (runs collection health as a sub-check)
+- [[drift]] — Schema drift detection (complement to collection health)

--- a/plugins/archivist/skills/vault-curator/scripts/check_collection_health.py
+++ b/plugins/archivist/skills/vault-curator/scripts/check_collection_health.py
@@ -22,9 +22,10 @@ Usage:
     uv run check_collection_health.py <vault-path> [options]
 
 Options:
-    --scope <path>     Limit scan to vault-relative folder (e.g. "700 Notes")
-    --folder <path>    Check a single specific folder (vault-relative)
-    --dry-run          Show candidate folders without running health checks
+    --scope <path>              Limit scan to vault-relative folder (e.g. "700 Notes")
+    --folder <path>             Check a single specific folder (vault-relative)
+    --coverage-threshold <pct>  Minimum fileClass coverage % for density-based detection (default: 60)
+    --dry-run                   Show candidate folders without running health checks
 
 Returns:
     JSON list of collection health reports:
@@ -207,8 +208,8 @@ def check_collection(
     }
 
 
-def is_candidate_collection(folder: Path) -> bool:
-    """A folder is a candidate collection if it has a folder note OR ≥5 notes with ≥60% sharing a fileClass."""
+def is_candidate_collection(folder: Path, coverage_threshold: float = 60.0) -> bool:
+    """A folder is a candidate collection if it has a folder note OR ≥5 notes with ≥coverage_threshold% sharing a fileClass."""
     name = folder.name
 
     # Skip hidden, template, or system folders
@@ -237,17 +238,17 @@ def is_candidate_collection(folder: Path) -> bool:
         return False
     counter = Counter(fileclasses)
     top_count = counter.most_common(1)[0][1]
-    return (top_count / len(notes)) >= 0.6
+    return (top_count / len(notes)) >= (coverage_threshold / 100.0)
 
 
-def find_candidate_collections(vault_path: Path, scope: str | None) -> list[Path]:
+def find_candidate_collections(vault_path: Path, scope: str | None, coverage_threshold: float = 60.0) -> list[Path]:
     search_root = vault_path / scope if scope else vault_path
     if not search_root.exists():
         raise ValueError(f"Scope path does not exist: {search_root}")
 
     candidates = []
     for folder in sorted(search_root.iterdir()):
-        if folder.is_dir() and is_candidate_collection(folder):
+        if folder.is_dir() and is_candidate_collection(folder, coverage_threshold):
             candidates.append(folder)
     return candidates
 
@@ -264,6 +265,7 @@ def main():
     vault_path_str = args[0]
     scope = None
     target_folder = None
+    coverage_threshold = 60.0
     dry_run = False
 
     i = 1
@@ -273,6 +275,9 @@ def main():
             i += 2
         elif args[i] == "--folder" and i + 1 < len(args):
             target_folder = args[i + 1]
+            i += 2
+        elif args[i] == "--coverage-threshold" and i + 1 < len(args):
+            coverage_threshold = float(args[i + 1])
             i += 2
         elif args[i] == "--dry-run":
             dry_run = True
@@ -286,7 +291,7 @@ def main():
         if target_folder:
             candidates = [vault_path / target_folder]
         else:
-            candidates = find_candidate_collections(vault_path, scope)
+            candidates = find_candidate_collections(vault_path, scope, coverage_threshold)
 
         if dry_run:
             print(json.dumps({

--- a/plugins/archivist/skills/vault-curator/scripts/generate_canvas.py
+++ b/plugins/archivist/skills/vault-curator/scripts/generate_canvas.py
@@ -21,6 +21,9 @@ Options:
     --scope <path>       Vault-relative folder to scan (required)
     --output <name>      Output filename (default: _knowledge-map-YYYY-MM-DD.canvas)
     --max-nodes <n>      Maximum nodes before clustering (default: 50)
+    --node-width <px>    Width of each file node in pixels (default: 300)
+    --node-height <px>   Height of each file node in pixels (default: 120)
+    --no-write           Return JSON without writing any file (agent controls write)
     --dry-run            Show what would be generated without writing
 
 Returns:
@@ -30,7 +33,8 @@ Returns:
         "canvas_path": "Work/Projects/_knowledge-map-2026-02-16.canvas",
         "nodes": 35,
         "edges": 42,
-        "clusters": 0
+        "clusters": 0,
+        "total_notes_scanned": 42
     }
 """
 
@@ -47,9 +51,7 @@ from collections import defaultdict
 import frontmatter
 
 
-# --- Layout constants ---
-NODE_WIDTH = 300
-NODE_HEIGHT = 120
+# --- Layout constants (spacing/padding are internal; width/height are user-facing via CLI args) ---
 NODE_SPACING_X = 80
 NODE_SPACING_Y = 60
 GROUP_PADDING = 30
@@ -232,7 +234,7 @@ def cluster_notes(
     return top_notes, top_edges, clusters
 
 
-def grid_layout(count: int) -> list[tuple[int, int]]:
+def grid_layout(count: int, node_width: int, node_height: int) -> list[tuple[int, int]]:
     """Calculate grid positions for n nodes. Returns list of (x, y) tuples."""
     if count == 0:
         return []
@@ -243,8 +245,8 @@ def grid_layout(count: int) -> list[tuple[int, int]]:
     for i in range(count):
         row = i // cols
         col = i % cols
-        x = col * (NODE_WIDTH + NODE_SPACING_X)
-        y = row * (NODE_HEIGHT + NODE_SPACING_Y)
+        x = col * (node_width + NODE_SPACING_X)
+        y = row * (node_height + NODE_SPACING_Y)
         positions.append((x, y))
 
     return positions
@@ -268,9 +270,11 @@ def generate_canvas(
     notes: list[dict],
     edges: list[tuple[int, int]],
     clusters: list[dict],
+    node_width: int = 300,
+    node_height: int = 120,
 ) -> dict:
     """Generate JSON Canvas data structure."""
-    positions = grid_layout(len(notes))
+    positions = grid_layout(len(notes), node_width, node_height)
     nodes = []
     node_ids = []
 
@@ -285,16 +289,16 @@ def generate_canvas(
             # Size group to roughly contain sub-notes
             sub_cols = math.ceil(math.sqrt(sub_count))
             sub_rows = math.ceil(sub_count / max(sub_cols, 1))
-            group_w = sub_cols * (NODE_WIDTH + NODE_SPACING_X) + GROUP_PADDING * 2
-            group_h = sub_rows * (NODE_HEIGHT + NODE_SPACING_Y) + GROUP_PADDING * 2 + GROUP_LABEL_HEIGHT
+            group_w = sub_cols * (node_width + NODE_SPACING_X) + GROUP_PADDING * 2
+            group_h = sub_rows * (node_height + NODE_SPACING_Y) + GROUP_PADDING * 2 + GROUP_LABEL_HEIGHT
 
             group_node = {
                 "id": node_id,
                 "type": "group",
                 "x": x,
                 "y": y,
-                "width": max(group_w, NODE_WIDTH + GROUP_PADDING * 2),
-                "height": max(group_h, NODE_HEIGHT + GROUP_PADDING * 2 + GROUP_LABEL_HEIGHT),
+                "width": max(group_w, node_width + GROUP_PADDING * 2),
+                "height": max(group_h, node_height + GROUP_PADDING * 2 + GROUP_LABEL_HEIGHT),
                 "label": cluster["label"],
             }
             color = fileclass_color("cluster")
@@ -303,7 +307,7 @@ def generate_canvas(
             nodes.append(group_node)
 
             # Add sub-notes inside the group
-            sub_positions = grid_layout(sub_count)
+            sub_positions = grid_layout(sub_count, node_width, node_height)
             for sub_note, (sx, sy) in zip(cluster["notes"], sub_positions):
                 sub_id = gen_id()
                 sub_node = {
@@ -311,8 +315,8 @@ def generate_canvas(
                     "type": "file",
                     "x": x + GROUP_PADDING + sx,
                     "y": y + GROUP_PADDING + GROUP_LABEL_HEIGHT + sy,
-                    "width": NODE_WIDTH,
-                    "height": NODE_HEIGHT,
+                    "width": node_width,
+                    "height": node_height,
                     "file": sub_note["path"],
                 }
                 color = fileclass_color(sub_note.get("file_class", ""))
@@ -326,8 +330,8 @@ def generate_canvas(
                 "type": "file",
                 "x": x,
                 "y": y,
-                "width": NODE_WIDTH,
-                "height": NODE_HEIGHT,
+                "width": node_width,
+                "height": node_height,
                 "file": note["path"],
             }
             color = fileclass_color(note.get("file_class", ""))
@@ -365,7 +369,10 @@ def main():
     scope = None
     output_name = None
     max_nodes = 50
+    node_width = 300
+    node_height = 120
     dry_run = False
+    no_write = False
 
     # Parse args
     i = 1
@@ -379,6 +386,15 @@ def main():
         elif args[i] == "--max-nodes" and i + 1 < len(args):
             max_nodes = int(args[i + 1])
             i += 2
+        elif args[i] == "--node-width" and i + 1 < len(args):
+            node_width = int(args[i + 1])
+            i += 2
+        elif args[i] == "--node-height" and i + 1 < len(args):
+            node_height = int(args[i + 1])
+            i += 2
+        elif args[i] == "--no-write":
+            no_write = True
+            i += 1
         elif args[i] == "--dry-run":
             dry_run = True
             i += 1
@@ -390,6 +406,14 @@ def main():
             "status": "error",
             "error": "Must specify --scope <path>",
         }))
+        sys.exit(1)
+
+    if node_width <= 0:
+        print(json.dumps({"status": "error", "error": "node-width must be > 0"}))
+        sys.exit(1)
+
+    if node_height <= 0:
+        print(json.dumps({"status": "error", "error": "node-height must be > 0"}))
         sys.exit(1)
 
     try:
@@ -433,29 +457,11 @@ def main():
 
         edges = build_edges(notes)
 
-        if not edges and len(notes) > 1:
-            # No wikilinks between notes — still generate but note it
-            pass
-
         # Cluster if needed
         top_notes, top_edges, clusters = cluster_notes(notes, edges, max_nodes)
 
-        # Generate canvas
-        canvas_data = generate_canvas(top_notes, top_edges, clusters)
-
-        # Handle existing canvas
-        if output_path.exists():
-            # Append date suffix to avoid overwrite
-            stem = output_path.stem
-            suffix = 1
-            while output_path.exists():
-                output_path = output_path.parent / f"{stem}-{suffix}.canvas"
-                suffix += 1
-            rel_output = str(output_path.relative_to(vault_path))
-
-        # Write canvas file
-        with open(output_path, 'w') as f:
-            json.dump(canvas_data, f, indent=2)
+        # Generate canvas data
+        canvas_data = generate_canvas(top_notes, top_edges, clusters, node_width, node_height)
 
         result = {
             "status": "success",
@@ -466,6 +472,31 @@ def main():
             "clusters": len(clusters),
             "total_notes_scanned": len(notes),
         }
+
+        if no_write:
+            # Return full canvas data without writing — agent controls write decision
+            result["canvas_data"] = canvas_data
+            if not edges:
+                result["message"] = "No wikilinks found between notes in scope. Canvas shows notes without connections."
+            if clusters:
+                result["message"] = f"Large scope ({len(notes)} notes) clustered into {len(clusters)} group(s) to stay under {max_nodes}-node cap."
+            print(json.dumps(result, indent=2, default=str))
+            return
+
+        # Handle existing canvas
+        if output_path.exists():
+            # Append date suffix to avoid overwrite
+            stem = output_path.stem
+            suffix = 1
+            while output_path.exists():
+                output_path = output_path.parent / f"{stem}-{suffix}.canvas"
+                suffix += 1
+            rel_output = str(output_path.relative_to(vault_path))
+            result["canvas_path"] = rel_output
+
+        # Write canvas file
+        with open(output_path, 'w') as f:
+            json.dump(canvas_data, f, indent=2)
 
         if not edges:
             result["message"] = "No wikilinks found between notes in scope. Canvas shows notes without connections. Consider adding [[wikilinks]] to connect related notes."

--- a/plugins/archivist/skills/vault-curator/scripts/generate_canvas.py
+++ b/plugins/archivist/skills/vault-curator/scripts/generate_canvas.py
@@ -255,13 +255,16 @@ def grid_layout(count: int, node_width: int, node_height: int) -> list[tuple[int
 def fileclass_color(file_class: str) -> str | None:
     """Map fileClass to a canvas preset color for visual distinction."""
     mapping = {
-        'meeting': '2',    # Orange
-        'person': '5',     # Cyan
-        'project': '4',    # Green
-        'company': '6',    # Purple
-        'moc': '3',        # Yellow
-        'log': '1',        # Red
-        'cluster': '6',    # Purple for clusters
+        'meeting': '2',     # Orange
+        'person': '5',      # Cyan
+        'project': '4',     # Green
+        'company': '6',     # Purple
+        'moc': '3',         # Yellow
+        'log': '1',         # Red
+        'cluster': '6',     # Purple for clusters
+        'workflow': '3',    # Yellow
+        'capture': '2',     # Orange
+        'template': '5',    # Cyan
     }
     return mapping.get(file_class.lower()) if file_class else None
 
@@ -339,7 +342,47 @@ def generate_canvas(
                 node["color"] = color
             nodes.append(node)
 
-    # Generate edges
+    # Generate fileClass group nodes (overlay groups around file nodes by fileClass)
+    fileclass_to_node_ids: dict[str, list[str]] = defaultdict(list)
+    for note, node_id in zip(notes, node_ids):
+        if not note.get("_is_cluster"):
+            fc = note.get("file_class", "").strip()
+            group_key = fc if fc else "Uncategorized"
+            fileclass_to_node_ids[group_key].append(node_id)
+
+    # Build a map from node_id to its (x, y, width, height) for group sizing
+    node_bounds: dict[str, tuple[int, int, int, int]] = {}
+    for node in nodes:
+        if node.get("type") == "file":
+            node_bounds[node["id"]] = (node["x"], node["y"], node["width"], node["height"])
+
+    for fc_label, member_ids in fileclass_to_node_ids.items():
+        member_rects = [node_bounds[nid] for nid in member_ids if nid in node_bounds]
+        if not member_rects:
+            continue
+        xs = [r[0] for r in member_rects]
+        ys = [r[1] for r in member_rects]
+        x2s = [r[0] + r[2] for r in member_rects]
+        y2s = [r[1] + r[3] for r in member_rects]
+        gx = min(xs) - GROUP_PADDING
+        gy = min(ys) - GROUP_PADDING - GROUP_LABEL_HEIGHT
+        gw = max(x2s) - min(xs) + GROUP_PADDING * 2
+        gh = max(y2s) - min(ys) + GROUP_PADDING * 2 + GROUP_LABEL_HEIGHT
+        group_node: dict = {
+            "id": gen_id(),
+            "type": "group",
+            "x": gx,
+            "y": gy,
+            "width": max(gw, node_width + GROUP_PADDING * 2),
+            "height": max(gh, node_height + GROUP_PADDING * 2 + GROUP_LABEL_HEIGHT),
+            "label": fc_label,
+        }
+        color = fileclass_color(fc_label)
+        if color:
+            group_node["color"] = color
+        nodes.append(group_node)
+
+    # Generate edges with direction markers
     canvas_edges = []
     for src, dst in edges:
         if src < len(node_ids) and dst < len(node_ids):
@@ -347,8 +390,10 @@ def generate_canvas(
                 "id": gen_id(),
                 "fromNode": node_ids[src],
                 "fromSide": "right",
+                "fromEnd": "none",
                 "toNode": node_ids[dst],
                 "toSide": "left",
+                "toEnd": "arrow",
             })
 
     return {"nodes": nodes, "edges": canvas_edges}

--- a/plugins/archivist/skills/vault-curator/scripts/merge_notes.py
+++ b/plugins/archivist/skills/vault-curator/scripts/merge_notes.py
@@ -20,6 +20,7 @@ Usage:
 Options:
     --source <path>    Source note path (relative to vault) — will be absorbed
     --target <path>    Target note path (relative to vault) — will survive
+    --no-write         Return merged content as JSON without writing (agent controls write)
     --dry-run          Show planned merge without writing
 
 Returns:
@@ -33,7 +34,8 @@ Returns:
             "conflicts": [{"property": "type", "source": "meeting", "target": "standup"}],
             "merged_lists": {"tags": ["a", "b", "c"]}
         },
-        "content_appended": true
+        "content_appended": true,
+        "target_content": "---\n..."  // only present with --no-write; full merged markdown
     }
 """
 
@@ -165,6 +167,7 @@ def main():
     source_path = None
     target_path = None
     dry_run = False
+    no_write = False
 
     # Parse args
     i = 1
@@ -175,6 +178,9 @@ def main():
         elif args[i] == "--target" and i + 1 < len(args):
             target_path = args[i + 1]
             i += 2
+        elif args[i] == "--no-write":
+            no_write = True
+            i += 1
         elif args[i] == "--dry-run":
             dry_run = True
             i += 1
@@ -238,21 +244,28 @@ def main():
             result["has_conflicts"] = True
             result["message"] = f"{len(fm_changes['conflicts'])} property conflict(s) require user resolution"
 
-        if not dry_run:
-            # Apply frontmatter changes
-            for key, val in fm_changes["added"].items():
-                target_post.metadata[key] = val
-            for key, val in fm_changes["merged_lists"].items():
-                target_post.metadata[key] = val
+        if dry_run:
+            print(json.dumps(result, indent=2, default=str))
+            return
 
-            # Apply content merge
-            target_post.content = merged_content
+        # Apply frontmatter changes to get the final merged state
+        for key, val in fm_changes["added"].items():
+            target_post.metadata[key] = val
+        for key, val in fm_changes["merged_lists"].items():
+            target_post.metadata[key] = val
+        target_post.content = merged_content
+        merged_text = frontmatter.dumps(target_post)
 
-            # Write target
-            with open(target_file, 'w', encoding='utf-8') as f:
-                f.write(frontmatter.dumps(target_post))
+        if no_write:
+            # Return merged content without writing — agent controls write decision
+            result["target_content"] = merged_text
+            print(json.dumps(result, indent=2, default=str))
+            return
 
-            result["written"] = str(target_file.relative_to(vault_path))
+        # Write target
+        with open(target_file, 'w', encoding='utf-8') as f:
+            f.write(merged_text)
+        result["written"] = str(target_file.relative_to(vault_path))
 
         print(json.dumps(result, indent=2, default=str))
 

--- a/plugins/archivist/skills/vault-curator/scripts/redirect_links.py
+++ b/plugins/archivist/skills/vault-curator/scripts/redirect_links.py
@@ -18,6 +18,7 @@ Options:
     --old <name>       Old note name (without .md extension)
     --new <name>       New note name (without .md extension)
     --scope <path>     Limit scan to vault-relative folder (default: entire vault)
+    --no-write         Return affected file content as JSON without writing (capped at 50 files)
     --dry-run          Show affected files without writing
 
 Returns:
@@ -32,6 +33,14 @@ Returns:
         ],
         "total_replacements": 15,
         "total_files": 5
+    }
+
+    With --no-write, affected_files entries also include "content_after".
+    If >50 files would be affected, returns:
+    {
+        "status": "too_many",
+        "affected_count": N,
+        "message": "Too many files to return inline. Use script-controlled mode (omit --no-write) with explicit approval."
     }
 """
 
@@ -77,12 +86,16 @@ def build_link_patterns(old_name: str) -> list[tuple[re.Pattern, str]]:
     ]
 
 
+NO_WRITE_FILE_CAP = 50
+
+
 def scan_and_replace(
     vault_path: Path,
     old_name: str,
     new_name: str,
     scope: str | None,
     dry_run: bool,
+    no_write: bool = False,
 ) -> dict:
     """Scan vault for wikilinks and replace them."""
     search_root = vault_path / scope if scope else vault_path
@@ -110,14 +123,29 @@ def scan_and_replace(
 
         if file_replacements > 0:
             rel_path = str(md_file.relative_to(vault_path))
-            affected_files.append({
+            entry: dict = {
                 "path": rel_path,
                 "replacements": file_replacements,
-            })
+            }
+            if no_write or dry_run:
+                # Include computed content for agent to apply with Edit tool
+                entry["content_after"] = new_content
+            affected_files.append(entry)
             total_replacements += file_replacements
 
-            if not dry_run:
+            if not dry_run and not no_write:
                 md_file.write_text(new_content, encoding='utf-8')
+
+    if no_write and len(affected_files) > NO_WRITE_FILE_CAP:
+        return {
+            "status": "too_many",
+            "affected_count": len(affected_files),
+            "total_replacements": total_replacements,
+            "message": (
+                f"Too many files ({len(affected_files)}) to return inline. "
+                "Use script-controlled mode (omit --no-write) with explicit user approval."
+            ),
+        }
 
     return {
         "affected_files": affected_files,
@@ -142,6 +170,7 @@ def main():
     new_name = None
     scope = None
     dry_run = False
+    no_write = False
 
     # Parse args
     i = 1
@@ -155,6 +184,9 @@ def main():
         elif args[i] == "--scope" and i + 1 < len(args):
             scope = args[i + 1]
             i += 2
+        elif args[i] == "--no-write":
+            no_write = True
+            i += 1
         elif args[i] == "--dry-run":
             dry_run = True
             i += 1
@@ -178,7 +210,10 @@ def main():
     try:
         vault_path = validate_vault_path(vault_path_str)
 
-        result = scan_and_replace(vault_path, old_name, new_name, scope, dry_run)
+        result = scan_and_replace(vault_path, old_name, new_name, scope, dry_run, no_write)
+        if result.get("status") == "too_many":
+            print(json.dumps(result, indent=2))
+            return
         result["status"] = "dry_run" if dry_run else "success"
         result["old_name"] = old_name
         result["new_name"] = new_name


### PR DESCRIPTION
## Summary

- Add `--no-write` primitives to `generate_canvas.py`, `merge_notes.py`, `redirect_links.py` so agent controls file writes via Write/Edit tools
- Enrich archivist init with vault signals (orphan count, collection health)
- Add delete workflows for canvas, templates, and Bases files
- Add multi-vault `.local.md` support with named `vaults:` profiles
- Add `/help` and `/workflows` slash commands for capability discovery
- Externalize hardcoded thresholds as CLI args (`--coverage-threshold`, `--node-width`, `--node-height`)
- Add fileClass group nodes and edge direction markers to canvas output
- Add reference files: `collection-health-criteria.md`, `vault-analysis-checks.md`, `frontmatter-schema-reference.md`
- Update agent-native audit scores to post-v1.21.0 results

Closes #160

## Test plan

- [ ] Verify `--no-write` on all three scripts returns JSON without writing files
- [ ] Verify archivist init surfaces orphan count and collection health signals
- [ ] Verify `/help` lists all commands; `/workflows` reads vault profile tables
- [ ] Verify multi-vault `.local.md` selects correct vault
- [ ] Verify canvas includes fileClass group nodes and directed edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)