### PR TITLE
feat(foundry): Add reference provenance tracking and freshness detection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,7 +36,7 @@
       "name": "foundry",
       "description": "Plugin development lifecycle toolkit — evaluate, improve, and publish skills and agents. Consolidates skillsmith, marketplace-manager, and agentsmith.",
       "category": "development",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "J. Greg Williams",
         "email": "283704+totallyGreg@users.noreply.github.com"

--- a/docs/plans/2026-04-28-001-feat-reference-provenance-freshness-plan.md
+++ b/docs/plans/2026-04-28-001-feat-reference-provenance-freshness-plan.md
@@ -1,0 +1,508 @@
+---
+title: "feat: Add reference provenance tracking and freshness detection"
+type: feat
+status: active
+date: 2026-04-28
+---
+
+# feat: Add reference provenance tracking and freshness detection
+
+## Overview
+
+Add a self-improvement capability to skills by tracking where reference content comes from and detecting when it goes stale. This generalizes a production-proven pattern from the prisma-airs plugin into a foundry-level capability that any skill can use. Additionally, support tracking cross-plugin dependencies (e.g., archivist referencing obsidian plugins) so skills that rely on other plugins can detect when new functionality has been added upstream.
+
+---
+
+## Problem Frame
+
+Skills accumulate reference files that derive from external sources — API docs, engineering repos, upstream plugins, Slack channels. Once written, these references become invisible liabilities: there is no mechanism to detect when the upstream source has changed, new features have been added, or content has drifted. This makes staleness invisible until a human manually notices.
+
+The prisma-airs plugin solved this for itself with a domain-specific refresh workflow including provenance frontmatter, a freshness checker script, and a `/refresh-references` command. That pattern should be generalized so any skill — including skills that depend on other Claude Code plugins — can benefit.
+
+---
+
+## Requirements Trace
+
+- R1. Standardize a provenance frontmatter format for reference files in the AgentSkills specification
+- R2. Build a generic freshness detection script that works on any skill with provenance-tracked references
+- R3. Add a Reference Currency metric to evaluate_skill.py (opt-in, no penalty for skills without provenance)
+- R4. Create an `/ss-refresh` command that guides reference updates for any skill
+- R5. Support cross-plugin dependency tracking as a source type (skills referencing other plugins)
+- R6. Integrate freshness awareness into existing skillsmith workflows (`ss-improve`, `ss-research`, `init_skill.py`)
+- R7. Dogfood: add provenance frontmatter to foundry's own references
+- R8. Validate against ai-risk-mapper as primary test case — its references track a GitHub repo (cosai-oasis/secure-ai-tooling) with structured YAML/JSON schemas and bundled assets
+
+---
+
+## Scope Boundaries
+
+- Not changing the overall skillsmith evaluation weight distribution (Reference Currency is a sixth dimension that adjusts weights proportionally)
+- Not building domain-specific parsers (skills handle those via `custom_checker`)
+- Not auto-updating references — freshness detection reports drift; humans decide what to change
+- Not requiring provenance on all references — opt-in with graceful neutral scoring
+
+### Deferred to Follow-Up Work
+
+- Custom parser registration via `custom_checker` frontmatter field: separate iteration after core provenance lands
+- PostToolUse hook for stale-reference warnings on edit: explore after metrics integration proves useful
+- Automated scheduled refresh runs: needs cron/CI infrastructure beyond current scope
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **prisma-airs prior art**: `refresh_references.py` (492 lines) — production provenance checker with `last_verified`, `sources`, `engineering_sources` frontmatter; supports GitLab, GitHub, Slack, URL probes, and full-audit mode
+- **prisma-airs `/refresh-references` command**: 10-step workflow — freshness report → identify gaps → research sources → update references → evaluate → version bump → commit/MR
+- **prisma-airs reference frontmatter format**: `last_verified` date, `sources` list (description + URL), `engineering_sources` list (gitlab/github project IDs + paths)
+- **evaluate_skill.py**: 3,169 lines, 5 dimensions with configurable weights. `calculate_overall_score()` at line 1114 — weights sum to 1.0. Adding a 6th dimension requires proportional redistribution
+- **`init_skill.py`**: 595 lines, 3 templates (minimal/standard/complete). Standard and complete templates create `references/` with placeholder files — good injection point for provenance template
+- **`validate_file_references()`** at line 1210: validates orphaned/missing references — can co-locate freshness validation
+- **`parse_frontmatter()`** at line 637: already parses YAML frontmatter from SKILL.md — reference files use the same format
+- **Hook system**: `on-skill-edit.sh` triggers on SKILL.md writes — reference file edits don't currently trigger hooks
+
+### Institutional Learnings
+
+- **Plugin validation pipeline**: 6-step mandatory pre-commit workflow (version bump → eval → export row → plugin-validator → plugin version → marketplace sync). New scripts must fit this flow
+- **Delegation principle**: Each tool retains its identity. `check_freshness.py` should be a standalone tool that `ss-refresh`, `ss-improve`, and `ss-research` orchestrate — not embedded in any of them
+- **False positives**: `validate_file_references()` has known false positives with paths in documentation examples. `check_freshness.py` should avoid this pattern
+- **Self-referential design**: Skillsmith evaluates itself. Foundry references getting provenance frontmatter (R7) ensures the new metric exercises its own tooling
+
+### ai-risk-mapper as Test Case
+
+The ai-risk-mapper plugin is the ideal validation target because its references exhibit a different pattern from prisma-airs:
+- **6 reference files** (1,360 total lines) tracking the CoSAI framework from `cosai-oasis/secure-ai-tooling` GitHub repo
+- **Bundled assets** — `assets/cosai-schemas/` contains cached YAML and JSON schema files fetched by `fetch_cosai_schemas.py`
+- **Structured upstream data** — references like `schemas_reference.md` and `cosai_overview.md` track specific GitHub repo paths (YAML data files, JSON schema files)
+- **Prior manual refresh** — `docs/plans/2026-02-25-feat-cosai-upstream-data-refresh-plan.md` documents a painful manual upstream sync (persona model change, taxonomy fixes, fabricated data cleanup), exactly the kind of drift the provenance system should detect automatically
+- **No existing provenance frontmatter** — references cite GitHub URLs in prose but have no structured tracking
+
+This exercises the `github` source type with multiple tracked paths and validates that `check_freshness.py` can handle the pattern where references summarize structured data from a GitHub repo rather than just linking to documentation URLs.
+
+### User Input: Cross-Plugin Dependency Tracking
+
+The user specifically requested that skills referencing other plugins (e.g., archivist referencing obsidian plugins) should be able to detect when those plugins add new features. This maps to a new source type `plugin` in the provenance spec that checks installed plugin versions, changelogs, or marketplace metadata.
+
+---
+
+## Key Technical Decisions
+
+- **Opt-in scoring**: Skills without provenance frontmatter score neutral (100) on Reference Currency, not penalized. This avoids forcing adoption while rewarding skills that track provenance
+- **Separate script, not embedded**: `check_freshness.py` is a standalone script in `skillsmith/scripts/`, following the delegation principle. It is not coupled to `evaluate_skill.py` internals
+- **`evaluate_skill.py` calls `check_freshness.py`**: The `--check-freshness` flag invokes the script as a subprocess, following the existing pattern where evaluate stays the orchestrator
+- **Source-type extensibility**: Four built-in source types (`web`, `github`, `gitlab`, `slack`) plus `plugin` for cross-plugin dependencies. Custom parsers deferred to follow-up
+- **GitHub source handles both doc URLs and structured data repos**: The `github` type must work for both simple documentation URLs (like Anthropic's guide) and structured repos with tracked paths containing YAML/JSON data files (like `cosai-oasis/secure-ai-tooling`). Path-level commit tracking is critical for the latter pattern
+- **Weight redistribution**: Adding Reference Currency as a 6th dimension. Take weight proportionally from all existing dimensions so their relative importance stays the same (redistribute 0.08 from 5 existing dimensions)
+- **Frontmatter compatibility**: Use the same field names as prisma-airs where applicable (`last_verified`, `sources`) for consistency, but make the format more generic (no `engineering_sources` — just `sources` with a `type` discriminator)
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should `check_freshness.py` import `evaluate_skill.py` or vice versa?**: Neither. `check_freshness.py` is standalone. `evaluate_skill.py` calls it as a subprocess when `--check-freshness` is passed, captures structured output, and incorporates the score. This keeps both scripts independently testable and avoids circular dependencies
+- **How should cross-plugin dependencies be checked?**: Via the `plugin` source type — checks the installed plugin's `plugin.json` version, compares against a `known_version` in provenance, and optionally reads CHANGELOG.md or README.md for new capabilities
+- **What staleness threshold?**: 90 days, matching prisma-airs. Configurable via `--threshold-days` flag
+
+### Deferred to Implementation
+
+- Exact JSON output format from `check_freshness.py` — will be determined when implementing structured output
+- How to gracefully degrade when `gh`/`glab` CLI tools are not installed — pattern exists in prisma-airs, adapt as needed
+- Whether the `plugin` source type should check marketplace.json or installed plugin paths — implementation will explore both
+
+---
+
+## Output Structure
+
+```
+plugins/foundry/skills/skillsmith/
+├── scripts/
+│   ├── check_freshness.py          (new — generic freshness checker)
+│   └── evaluate_skill.py           (modify — add Reference Currency dimension)
+├── references/
+│   ├── agentskills_specification.md (modify — add provenance spec)
+│   └── validation_tools_guide.md   (modify — document Reference Currency metric)
+├── SKILL.md                         (modify — reference new content)
+plugins/foundry/commands/
+│   └── ss-refresh.md                (new — refresh command)
+```
+
+---
+
+## Implementation Units
+
+- U1. **Reference Provenance Specification**
+
+**Goal:** Define the standardized optional provenance frontmatter format in the AgentSkills specification.
+
+**Requirements:** R1, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `plugins/foundry/skills/skillsmith/references/agentskills_specification.md`
+
+**Approach:**
+- Add a new section "Reference Provenance (Optional)" after the existing reference management guidance
+- Define frontmatter schema: `last_verified` (date), `sources` list with `type` discriminator
+- Supported source types: `web` (URL probe), `github` (repo + paths), `gitlab` (project_id + paths), `slack` (channel_id), `plugin` (plugin name + known_version)
+- Include examples for each source type
+- Note that provenance is opt-in — references without it are valid
+
+**Patterns to follow:**
+- Existing frontmatter documentation style in `agentskills_specification.md`
+- prisma-airs reference frontmatter as proven prior art (simplify `engineering_sources` into unified `sources` list)
+
+**Test scenarios:**
+- Test expectation: none — specification documentation only
+
+**Verification:**
+- The new section is clear enough that a skill author can add provenance frontmatter to a reference without reading any other documentation
+
+---
+
+- U2. **Generic Freshness Detection Script**
+
+**Goal:** Build `check_freshness.py` that scans any skill's references for provenance frontmatter and reports staleness.
+
+**Requirements:** R2, R5
+
+**Dependencies:** U1
+
+**Files:**
+- Create: `plugins/foundry/skills/skillsmith/scripts/check_freshness.py`
+- Test: manual testing against prisma-airs references and foundry's own references (after U7)
+
+**Approach:**
+- PEP 723 inline metadata header (only `pyyaml` dependency, matching prisma-airs pattern)
+- Accept skill path as positional argument, default to current directory
+- Scan `references/` for files with YAML frontmatter containing `last_verified`
+- For each source type, check for activity since `last_verified`:
+  - `web`: HTTP HEAD check via curl subprocess, report status code
+  - `github`: `gh api repos/{repo}/commits?since={date}&path={path}` — report commit count
+  - `gitlab`: `glab api projects/{id}/repository/commits?since={date}&path={path}` — report commit count
+  - `slack`: Slack API `conversations.history` via curl with `$SLACK_USER_TOKEN` — report message count
+  - `plugin`: Check installed plugin version at `~/.claude/plugins/` against `known_version` in frontmatter; optionally read plugin's CHANGELOG.md or README.md for new entries
+- Flags: `--since <date>` override, `--full-audit` mode, `--threshold-days N` (default 90), `--format json` for machine-readable output, `--probe` for URL checks
+- Graceful degradation: warn on missing CLI tools, don't fail
+- Structured JSON output mode for programmatic consumption by `evaluate_skill.py`
+
+**Patterns to follow:**
+- `refresh_references.py` from prisma-airs (492 lines) — `parse_frontmatter()`, `check_engineering_activity()`, `check_url()` patterns
+- PEP 723 header style from existing foundry scripts
+- `utils.py` for `find_repo_root()` if needed
+
+**Test scenarios:**
+- Happy path: scan a skill directory with 3 provenance-tracked references, all within threshold → report "all fresh"
+- Happy path: scan a skill with 1 stale reference (last_verified > 90 days ago) → report staleness with source details
+- Edge case: reference has `last_verified` but no `sources` → warn, don't crash
+- Edge case: reference has `sources` but no `last_verified` → treat as stale (never verified)
+- Edge case: `gh`/`glab` not installed → warn per source, report what can be checked
+- Edge case: `plugin` source type with plugin not installed → warn, skip
+- Happy path: `--format json` outputs valid JSON parseable by `evaluate_skill.py`
+- Happy path: `--full-audit` shows all source activity regardless of `last_verified` cutoff
+
+**Verification:**
+- Running `uv run check_freshness.py <skill-path>` produces a readable markdown freshness report
+- Running with `--format json` produces structured output with per-reference scores
+
+---
+
+- U3. **Reference Currency Metric in evaluate_skill.py**
+
+**Goal:** Add Reference Currency as a sixth evaluation dimension, opt-in with neutral scoring for non-provenance skills.
+
+**Requirements:** R3
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `plugins/foundry/skills/skillsmith/scripts/evaluate_skill.py`
+
+**Approach:**
+- Add `calculate_reference_currency_score()` function that:
+  - Scans `references/` for files with provenance frontmatter
+  - If no references have provenance → return score 100 (neutral, opt-in)
+  - If provenance exists → run `check_freshness.py --format json` as subprocess, parse output
+  - Score = percentage of tracked references within staleness threshold
+- Update `calculate_overall_score()` to accept optional `reference_currency` parameter
+- Redistribute weights when Reference Currency is present (6 dimensions):
+  - Conciseness: 0.18 (was 0.20)
+  - Complexity: 0.18 (was 0.20)
+  - Spec Compliance: 0.27 (was 0.30)
+  - Progressive Disclosure: 0.18 (was 0.20)
+  - Description Quality: 0.09 (was 0.10)
+  - Reference Currency: 0.10 (new)
+- Add `--check-freshness` flag to CLI argument parser
+- When `--check-freshness` is passed OR provenance frontmatter is detected, include Reference Currency in output
+- Update `--explain` output to include Reference Currency coaching when applicable
+- Update `store_metrics_in_metadata()` to include reference_currency when scored
+
+**Patterns to follow:**
+- Existing dimension functions (`calculate_conciseness_score`, etc.) — return dict with `score` and `details` keys
+- Existing weight handling in `calculate_overall_score()` at line 1114
+- `--explain` output format in `print_explain_output()`
+
+**Test scenarios:**
+- Happy path: skill with no provenance references → Reference Currency = 100, overall score unchanged from 5-dimension calculation
+- Happy path: skill with all fresh provenance references → Reference Currency = 100
+- Happy path: skill with 2/4 stale provenance references → Reference Currency = 50
+- Edge case: skill with provenance but `check_freshness.py` not accessible → graceful fallback to neutral (100)
+- Happy path: `--explain` output includes Reference Currency coaching with "Why" and "To improve" sections
+- Integration: overall score with 6 dimensions matches expected weight redistribution (compare 5-dim and 6-dim results for same skill)
+
+**Verification:**
+- `uv run evaluate_skill.py <skill-with-provenance> --check-freshness` reports Reference Currency alongside existing 5 dimensions
+- Skills without provenance frontmatter see no change in their scores
+
+---
+
+- U4. **`/ss-refresh` Command**
+
+**Goal:** Create a slash command that guides reference updates for any skill, generalizing prisma-airs's `/refresh-references` workflow.
+
+**Requirements:** R4
+
+**Dependencies:** U2
+
+**Files:**
+- Create: `plugins/foundry/commands/ss-refresh.md`
+
+**Approach:**
+- Follow the prisma-airs `/refresh-references` command structure (10-step workflow) but make it generic:
+  1. Run `check_freshness.py` on target skill (incremental or full-audit mode)
+  2. Present freshness report to user
+  3. If gaps found, summarize which references need updating and which sources have activity
+  4. Ask user for confirmation to proceed
+  5. For each stale reference, research upstream sources using the source metadata:
+     - `web`: fetch via `defuddle parse --md` or `WebFetch`
+     - `github`/`gitlab`: read files via CLI API
+     - `slack`: fetch recent messages from channel
+     - `plugin`: read upstream plugin's SKILL.md, README, CHANGELOG
+  6. Update reference content and `last_verified` date
+  7. Update SKILL.md if new capabilities were added
+  8. Run skillsmith evaluation — block if score regresses
+  9. Version bump (PATCH for content updates, MINOR for new capabilities)
+  10. Optionally commit and create branch/PR
+- Use `${CLAUDE_PLUGIN_ROOT}` for script paths
+- Reference `allowed_tools: Bash, Read, Edit, Write, Glob, Grep, Agent, AskUserQuestion`
+
+**Patterns to follow:**
+- prisma-airs `refresh-references.md` command structure
+- Existing `ss-improve.md` for foundry command conventions (frontmatter, allowed_tools, step structure)
+
+**Test scenarios:**
+- Happy path: run on a skill with stale references → freshness report shows gaps, user confirms, references updated, eval passes
+- Happy path: run on a skill with all fresh references → "no gaps detected" message, stops early
+- Edge case: run on a skill with no provenance frontmatter → inform user that no references are tracked, suggest adding provenance
+- Integration: after refresh, `evaluate_skill.py --check-freshness` shows improved Reference Currency score
+
+**Verification:**
+- `/ss-refresh <skill-path>` produces a useful freshness report and can guide a reference update workflow
+
+---
+
+- U5. **Integrate Freshness into `ss-improve` and `ss-research`**
+
+**Goal:** Surface stale references as improvement opportunities in existing skillsmith workflows.
+
+**Requirements:** R6
+
+**Dependencies:** U2, U4
+
+**Files:**
+- Modify: `plugins/foundry/commands/ss-improve.md`
+- Modify: `plugins/foundry/commands/ss-research.md`
+
+**Approach:**
+- **`ss-improve`**: After running `evaluate_skill.py --explain`, check if any references have provenance frontmatter. If stale references exist, add a note: "Reference X hasn't been verified in N days. Run `/ss-refresh` to check for upstream changes." This is informational — don't auto-refresh during improvement
+- **`ss-research`**: Include freshness status in the research output. When reporting skill state, run `check_freshness.py` if provenance exists and report findings alongside existing evaluation metrics
+
+**Patterns to follow:**
+- Existing `ss-improve.md` step structure — add freshness check after evaluation step
+- Existing `ss-research.md` research output format
+
+**Test scenarios:**
+- Happy path: `/ss-improve` on a skill with stale references → improvement output includes freshness warning with `/ss-refresh` suggestion
+- Happy path: `/ss-research` on a skill with provenance → research output includes freshness status section
+- Edge case: skill has no provenance → no freshness-related output (clean absence, not a warning)
+
+**Verification:**
+- Running `/ss-improve` or `/ss-research` on a skill with provenance naturally surfaces freshness information without disrupting existing workflows
+
+---
+
+- U6. **Update `init_skill.py` Templates**
+
+**Goal:** Include provenance frontmatter template in scaffolded reference files for standard and complete templates.
+
+**Requirements:** R6
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `plugins/foundry/skills/skillsmith/scripts/init_skill.py`
+
+**Approach:**
+- In the `standard` template: add commented-out provenance frontmatter to `references/detailed_guide.md` as an example
+- In the `complete` template: add provenance frontmatter to at least one reference file (`references/detailed_guide.md`) with placeholder values
+- Include a brief comment in the generated reference explaining what provenance tracking does and linking to the spec
+
+**Patterns to follow:**
+- Existing template generation in `init_skill.py` — string templates with placeholder comments
+
+**Test scenarios:**
+- Happy path: `init_skill.py --template standard my-skill` creates reference file with commented provenance frontmatter example
+- Happy path: `init_skill.py --template complete my-skill` creates reference file with active provenance frontmatter placeholders
+- Edge case: `init_skill.py --template minimal my-skill` does not create any provenance content (minimal has no references/)
+
+**Verification:**
+- Scaffolded skills from standard/complete templates include provenance awareness in reference files
+
+---
+
+- U7. **Dogfood: Add Provenance to Foundry References**
+
+**Goal:** Add provenance frontmatter to foundry's own reference files as a proof of concept and self-test.
+
+**Requirements:** R7
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `plugins/foundry/skills/skillsmith/references/agentskills_specification.md`
+- Modify: `plugins/foundry/skills/skillsmith/references/skill_patterns.md`
+- Modify: `plugins/foundry/skills/skillsmith/references/testing_guide.md`
+
+**Approach:**
+- Add provenance frontmatter to the 3 references that have known upstream sources:
+  - `agentskills_specification.md` → sources: AgentSkills GitHub repo, agentskills.io spec page
+  - `skill_patterns.md` → sources: Anthropic's "Complete Guide to Building Skills for Claude" (web URL)
+  - `testing_guide.md` → sources: Anthropic's "Complete Guide to Building Skills for Claude" (web URL)
+- Set `last_verified` to today's date
+- Leave other references (internally-authored) without provenance — they don't track external sources
+
+**Patterns to follow:**
+- prisma-airs reference frontmatter (proven format)
+- The provenance spec defined in U1
+
+**Test scenarios:**
+- Test expectation: none — metadata-only changes to existing reference files
+- Integration: after U2 and U3 land, `check_freshness.py` and `evaluate_skill.py --check-freshness` work correctly on foundry's own references
+
+**Verification:**
+- Foundry's references with known upstream sources have valid provenance frontmatter
+- Running `check_freshness.py` on skillsmith produces a meaningful report
+
+---
+
+- U8. **Document Reference Currency in validation_tools_guide.md**
+
+**Goal:** Document the new metric, `check_freshness.py` usage, and `/ss-refresh` workflow in the validation tools guide.
+
+**Requirements:** R3, R4
+
+**Dependencies:** U2, U3, U4
+
+**Files:**
+- Modify: `plugins/foundry/skills/skillsmith/references/validation_tools_guide.md`
+- Modify: `plugins/foundry/skills/skillsmith/SKILL.md`
+
+**Approach:**
+- Add Reference Currency section to validation_tools_guide.md alongside existing metric documentation:
+  - Scoring model (opt-in neutral, proportional reduction for staleness)
+  - `check_freshness.py` CLI flags and usage examples
+  - `--check-freshness` flag for evaluate_skill.py
+  - `/ss-refresh` workflow overview
+- Update SKILL.md to contextually reference the new content where appropriate (provenance tracking, freshness checking)
+
+**Patterns to follow:**
+- Existing metric documentation sections in `validation_tools_guide.md` (scoring breakdown, flag reference, workflow examples)
+- SKILL.md reference mention style ("See `references/validation_tools_guide.md` for details on...")
+
+**Test scenarios:**
+- Test expectation: none — documentation only
+- Integration: `evaluate_skill.py --validate-references` does not flag the new content as orphaned
+
+**Verification:**
+- A skill developer reading the validation tools guide can understand what Reference Currency measures, how to enable it, and how to refresh stale references
+
+---
+
+- U9. **Test Case: Add Provenance to ai-risk-mapper References**
+
+**Goal:** Add provenance frontmatter to ai-risk-mapper's references as the primary validation test case, exercising the `github` source type with structured YAML/JSON upstream data.
+
+**Requirements:** R8
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `plugins/ai-risk-mapper/skills/ai-risk-mapper/references/cosai_overview.md`
+- Modify: `plugins/ai-risk-mapper/skills/ai-risk-mapper/references/schemas_reference.md`
+- Modify: `plugins/ai-risk-mapper/skills/ai-risk-mapper/references/exploration_guide.md`
+- Modify: `plugins/ai-risk-mapper/skills/ai-risk-mapper/references/personas_guide.md`
+- Modify: `plugins/ai-risk-mapper/skills/ai-risk-mapper/references/workflow_guide.md`
+- Modify: `plugins/ai-risk-mapper/skills/ai-risk-mapper/references/forms.md`
+
+**Approach:**
+- Add provenance frontmatter to each reference file that tracks the upstream CoSAI repo:
+  - `cosai_overview.md` → `github` source: `cosai-oasis/secure-ai-tooling`, paths: `risk-map/`
+  - `schemas_reference.md` → `github` source: `cosai-oasis/secure-ai-tooling`, paths: `risk-map/schemas/`
+  - `exploration_guide.md` → `github` source: `cosai-oasis/secure-ai-tooling`, paths: `risk-map/` (risk IDs, persona IDs, framework mappings all derive from upstream YAML)
+  - `personas_guide.md` → `github` source: `cosai-oasis/secure-ai-tooling`, paths: `risk-map/personas.yaml`
+  - `workflow_guide.md` → internally authored, may reference the CoSAI repo for validation patterns
+  - `forms.md` → internally authored, no upstream source (skip provenance or mark as internal)
+- Set `last_verified` to today's date for files with actual upstream sources
+- Run `check_freshness.py` against the ai-risk-mapper skill to validate it produces a meaningful report
+- Compare output against the manual refresh documented in `docs/plans/2026-02-25-feat-cosai-upstream-data-refresh-plan.md` — the provenance system should have detected the same drift signals
+
+**Patterns to follow:**
+- The provenance spec defined in U1
+- prisma-airs reference frontmatter as format example
+
+**Test scenarios:**
+- Happy path: `check_freshness.py plugins/ai-risk-mapper/skills/ai-risk-mapper` scans 6 references, reports freshness status for provenance-tracked files, skips internally-authored files
+- Happy path: `--full-audit` mode shows all GitHub commits since `last_verified` for tracked paths in `cosai-oasis/secure-ai-tooling`
+- Integration: if upstream CoSAI repo has commits since today, future runs will correctly report drift
+- Edge case: references with no upstream source (forms.md) are cleanly skipped, not flagged as errors
+
+**Verification:**
+- Running `check_freshness.py` on ai-risk-mapper produces a report that would have detected the persona model change and taxonomy updates documented in the Feb 2026 manual refresh plan
+- The provenance format accommodates structured data repos (YAML/JSON files), not just documentation URLs
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `ss-refresh` → `check_freshness.py` → external APIs (GitHub/GitLab/Slack/URL). `evaluate_skill.py --check-freshness` → `check_freshness.py --format json`. `ss-improve` and `ss-research` → `check_freshness.py` (informational). Hook system (`on-skill-edit.sh`) is NOT affected — reference file edits don't trigger it
+- **Error propagation:** External API failures (gh/glab not installed, Slack token missing, URL unreachable) should warn per-source and continue, never fail the overall operation. `check_freshness.py` failures in `evaluate_skill.py` should fall back to neutral (100) score
+- **State lifecycle risks:** `last_verified` dates in reference frontmatter are the only persistent state. No cache, no database. Risk of drift between actual verification and recorded date is mitigated by updating `last_verified` only through the `/ss-refresh` workflow
+- **API surface parity:** The `--check-freshness` flag in `evaluate_skill.py` extends the existing CLI interface. No breaking changes to existing flags or output format. JSON output adds a `reference_currency` key when present
+- **Unchanged invariants:** Existing 5-dimension scoring is unchanged for skills without provenance. Weight redistribution only activates when Reference Currency is scored. All existing `evaluate_skill.py` flags continue to work identically
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| External API rate limits (GitHub, GitLab, Slack) | `check_freshness.py` makes minimal API calls (1 per source per reference). Caching is unnecessary at this scale |
+| `check_freshness.py` adds latency to `evaluate_skill.py` | Only runs when `--check-freshness` flag is passed or provenance is detected. Subprocess isolation prevents blocking |
+| Weight redistribution changes existing scores | Only activates when Reference Currency is scored. Skills without provenance see identical scores. Change is small (0.02 per existing dimension) |
+| prisma-airs frontmatter format diverges from generic spec | The generic spec is a superset of prisma-airs format. Existing prisma-airs frontmatter is valid under the new spec with minor field mapping |
+
+---
+
+## Sources & References
+
+- Related issue: #165
+- Prior art: `/Users/gregwilliams/Documents/PAN_Projects/AIRS/claude-skills/plugins/prisma-airs/skills/prisma-airs/scripts/refresh_references.py`
+- Prior art: `/Users/gregwilliams/Documents/PAN_Projects/AIRS/claude-skills/plugins/prisma-airs/commands/refresh-references.md`
+- Existing code: `plugins/foundry/skills/skillsmith/scripts/evaluate_skill.py` (scoring system)
+- Existing code: `plugins/foundry/skills/skillsmith/scripts/init_skill.py` (scaffolding)
+- Existing spec: `plugins/foundry/skills/skillsmith/references/agentskills_specification.md`
+- Test case: `plugins/ai-risk-mapper/skills/ai-risk-mapper/references/` (6 files tracking cosai-oasis/secure-ai-tooling)
+- Test case prior refresh: `docs/plans/2026-02-25-feat-cosai-upstream-data-refresh-plan.md` (manual upstream sync that provenance should have caught)

--- a/plugins/ai-risk-mapper/skills/ai-risk-mapper/references/cosai_overview.md
+++ b/plugins/ai-risk-mapper/skills/ai-risk-mapper/references/cosai_overview.md
@@ -1,3 +1,12 @@
+---
+last_verified: 2026-04-28
+sources:
+  - type: github
+    repo: "cosai-oasis/secure-ai-tooling"
+    paths: ["risk-map/"]
+    description: "CoSAI Risk Map framework — components, risks, controls, personas"
+---
+
 # CoSAI Risk Map Framework Overview
 
 ## What is CoSAI?

--- a/plugins/ai-risk-mapper/skills/ai-risk-mapper/references/exploration_guide.md
+++ b/plugins/ai-risk-mapper/skills/ai-risk-mapper/references/exploration_guide.md
@@ -1,3 +1,12 @@
+---
+last_verified: 2026-04-28
+sources:
+  - type: github
+    repo: "cosai-oasis/secure-ai-tooling"
+    paths: ["risk-map/"]
+    description: "CoSAI Risk Map — risk IDs, persona IDs, framework mappings from upstream YAML"
+---
+
 # Interactive Exploration Guide
 
 This guide covers interactive exploration of the CoSAI Risk Map framework using CLI commands and the core analyzer API. Use these tools for ad-hoc queries, threat modeling sessions, and compliance mapping.

--- a/plugins/ai-risk-mapper/skills/ai-risk-mapper/references/personas_guide.md
+++ b/plugins/ai-risk-mapper/skills/ai-risk-mapper/references/personas_guide.md
@@ -1,3 +1,12 @@
+---
+last_verified: 2026-04-28
+sources:
+  - type: github
+    repo: "cosai-oasis/secure-ai-tooling"
+    paths: ["risk-map/personas.yaml"]
+    description: "CoSAI persona definitions — roles, responsibilities, ISO 22989 mappings"
+---
+
 # CoSAI Personas Guide
 
 The CoSAI Risk Map framework defines ten personas (8 active, 2 deprecated) aligned with ISO/IEC 22989 AI actor terminology. These personas identify who is impacted by risks and who is responsible for enacting controls across the AI ecosystem.

--- a/plugins/ai-risk-mapper/skills/ai-risk-mapper/references/schemas_reference.md
+++ b/plugins/ai-risk-mapper/skills/ai-risk-mapper/references/schemas_reference.md
@@ -1,3 +1,12 @@
+---
+last_verified: 2026-04-28
+sources:
+  - type: github
+    repo: "cosai-oasis/secure-ai-tooling"
+    paths: ["risk-map/schemas/"]
+    description: "CoSAI JSON schema definitions for validation and automation"
+---
+
 # CoSAI Schema Reference
 
 This document describes the JSON schema structures used in the CoSAI Risk Map framework for validation and automation.

--- a/plugins/foundry/.claude-plugin/plugin.json
+++ b/plugins/foundry/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foundry",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Plugin development lifecycle toolkit — evaluate, improve, and publish skills and agents. Consolidates skillsmith (skill quality), marketplace-manager (distribution/versioning), and agentsmith (agent quality) into a single plugin.",
   "author": {
     "name": "J. Greg Williams",

--- a/plugins/foundry/README.md
+++ b/plugins/foundry/README.md
@@ -46,7 +46,7 @@ Analyzes saved Claude Code session transcripts to identify where a skill failed 
 
 ### Current Metrics
 
-**Score: 100/100** (Excellent) — 2026-03-25
+**Score: 100/100** (Excellent) — 2026-04-28
 
 | Concs | Complx | Spec | Progr | Descr |
 |-------|--------|------|-------|-------|
@@ -56,6 +56,7 @@ Analyzes saved Claude Code session transcripts to identify where a skill failed 
 
 | Version | Date | Issue | Summary | Concs | Complx | Spec | Progr | Descr | Score |
 |---------|------|-------|---------|-------|--------|------|-------|-------|-------|
+| 6.9.0 | 2026-04-28 | [#165](https://github.com/totallyGreg/claude-mp/issues/165) | Reference provenance tracking: provenance spec in agentskills_specification.md, check_freshness.py generic script, Reference Currency 6th evaluation dimension, /ss-refresh command, ss-improve/ss-research freshness integration, init_skill.py templates | 100 | 100 | 100 | 100 | 100 | 100 |
 | 6.8.0 | 2026-03-25 | [#148](https://github.com/totallyGreg/claude-mp/issues/148) | Migrate skill README to plugin level: plugin-root discovery, scoped section replacement, auto-migration, compact metrics display, clearer column headers, validate_skill_name(), rename readme_template | 100 | 100 | 100 | 100 | 100 | 100 |
 | 6.7.0 | 2026-03-25 | [#146](https://github.com/totallyGreg/claude-mp/issues/146) | Anthropic guide alignment: use-case definition template, description formula + bad examples, body structure template, 5 skill patterns reference, 3-area testing guide, negative trigger coaching, over/undertrigger --explain signals | 100 | 100 | 100 | 100 | 100 | 100 |
 | 6.6.0 | 2026-03-22 | [#96](https://github.com/totallyGreg/claude-mp/issues/96), [#115](https://github.com/totallyGreg/claude-mp/issues/115), [#81](https://github.com/totallyGreg/claude-mp/issues/81), [#82](https://github.com/totallyGreg/claude-mp/issues/82), [#108](https://github.com/totallyGreg/claude-mp/issues/108), [#110](https://github.com/totallyGreg/claude-mp/issues/110) | Qualitative conciseness checks; context-aware ss-observe with --hint; orphan regex fix; IMPROVEMENT_PLAN.md migration; frontmatter auto-patch; commit-gate doc | 100 | 100 | 100 | 100 | 100 | 100 |

--- a/plugins/foundry/README.md
+++ b/plugins/foundry/README.md
@@ -86,4 +86,20 @@ Analyzes saved Claude Code session transcripts to identify where a skill failed 
 | 2.0.0 | 2026-02-03 | - | Standalone plugin migration | - | - | - | - | - | - |
 | 1.0.0 | 2025-12-21 | - | Initial release | - | - | - | - | - | - |
 
+## Skill: agentsmith
+
+### Current Metrics
+
+**Score: 93/100** (Good) — 2026-04-28
+
+| Concs | Complx | Spec | Progr | Descr |
+|-------|--------|------|-------|-------|
+| 100 | 80 | 100 | 85 | 100 |
+
+### Version History
+
+| Version | Date | Issue | Summary | Concs | Complx | Spec | Progr | Descr | Score |
+|---------|------|-------|---------|-------|--------|------|-------|-------|-------|
+| 1.0.0 | 2026-04-28 | - | Initial release — agent evaluation with 3 quality dimensions | 100 | 80 | 100 | 85 | 100 | 93 |
+
 **Metric Legend:** Concs=Conciseness, Complx=Complexity, Spec=Spec Compliance, Progr=Progressive Disclosure, Descr=Description Quality (0-100 scale)

--- a/plugins/foundry/commands/ss-improve.md
+++ b/plugins/foundry/commands/ss-improve.md
@@ -67,6 +67,18 @@ uv run ${CLAUDE_PLUGIN_ROOT}/skills/skillsmith/scripts/evaluate_skill.py $ARGUME
 
 Report scores and the top-3 improvements identified.
 
+## Step 1b: Check reference freshness (if provenance exists)
+
+If the evaluation output shows a Reference Currency score (indicating the skill has provenance-tracked references), run:
+
+```bash
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/skillsmith/scripts/check_freshness.py $ARGUMENTS --verbose
+```
+
+If stale references are found, note: "Reference X hasn't been verified in N days. Run `/ss-refresh` to check for upstream changes." This is informational — do not auto-refresh during improvement. Focus on the structural improvements from `--explain`.
+
+If no Reference Currency score appears in the evaluation, skip this step silently.
+
 ## Step 2: Apply improvements
 
 Work through the top-3 improvements from `--explain` output. For structural guidance (skill anatomy, writing style), invoke `plugin-dev:skill-development`.

--- a/plugins/foundry/commands/ss-refresh.md
+++ b/plugins/foundry/commands/ss-refresh.md
@@ -1,0 +1,110 @@
+---
+name: ss-refresh
+description: Detect stale references and guide updates for any skill with provenance-tracked references
+argument-hint: [skill-path]
+allowed_tools: Bash, Read, Edit, Write, Glob, Grep, Agent, AskUserQuestion
+---
+
+Run the reference freshness checker and guide updates for a skill at `$ARGUMENTS`.
+
+If no skill path provided, ask the user for it before proceeding.
+
+## Step 1: Verify target is a skill
+
+Check that `$ARGUMENTS` points to a directory containing `SKILL.md`. If not found, inform the user and stop.
+
+## Step 1a: Remap installed-cache paths to source
+
+Resolve `$ARGUMENTS` to a real absolute path, following any symlinks (`realpath` or Python `Path.resolve()`).
+
+Check whether the resolved path starts with `$HOME/.claude/plugins/`. If it does, remap to source using `marketplace.json` (same logic as `/ss-improve` Step 0a).
+
+## Step 2: Choose mode
+
+Ask the user which mode to run:
+- **Incremental** (default): Only detect activity newer than `last_verified`
+- **Full audit**: Show all source activity — use for initial catchups or thorough reviews
+
+## Step 3: Run the freshness report
+
+```bash
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/skillsmith/scripts/check_freshness.py \
+  "$SKILL_PATH" --probe --verbose
+```
+
+For full audit mode, add `--full-audit`.
+
+Present the output to the user. If no gaps or stale references are found, report that and stop.
+
+## Step 4: Identify what changed
+
+If gaps are detected (references with upstream activity or staleness), summarize:
+- Which references are stale and by how many days
+- Which sources have new commits, messages, or version drift
+- Which references need updating
+
+Ask the user: **"Update these references? This will modify reference files and bump the version."**
+
+If the user declines, stop.
+
+## Step 5: Research upstream sources
+
+For each reference that needs updating, read the upstream source content using the source metadata from the reference's YAML frontmatter:
+
+- **`web`**: Fetch via `defuddle parse --md <url>` or `WebFetch`
+- **`github`**: Read files via `gh api repos/{repo}/contents/{path}`
+- **`gitlab`**: Read files via `glab api projects/{id}/repository/files/{path}/raw?ref=main`
+- **`slack`**: Fetch recent messages from the channel via Slack API
+- **`plugin`**: Read the upstream plugin's SKILL.md, README.md, or CHANGELOG.md
+
+Focus on:
+- New features, endpoints, or capabilities
+- Changed schemas, types, or data structures
+- Deprecated or removed functionality
+
+## Step 6: Update references
+
+Edit each affected reference file:
+1. Incorporate new information from the upstream source
+2. Update `last_verified` date to today in the YAML frontmatter
+3. Keep existing content intact — only add or modify what changed
+4. Maintain the existing style and structure of each reference
+
+**Do NOT:**
+- Rewrite entire files — surgical updates only
+- Add marketing language — use engineering details
+- Remove existing content unless confirmed wrong
+- Change the file's overall organization
+
+## Step 7: Update SKILL.md if needed
+
+If new capabilities were added (e.g., new CLI commands, new features), update the SKILL.md to mention them. Keep it concise — details go in references.
+
+## Step 8: Evaluate
+
+Run the skillsmith evaluator to confirm no score regression:
+
+```bash
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/skillsmith/scripts/evaluate_skill.py "$SKILL_PATH"
+```
+
+If the foundry plugin's PostToolUse hook is active, it auto-evaluates on SKILL.md edits. If score dropped, fix before proceeding.
+
+## Step 9: Version bump
+
+Determine the version bump:
+- **PATCH** (x.y.Z): Only reference content updates, no new capabilities
+- **MINOR** (x.Y.0): New capabilities documented, backward-compatible
+
+Update version in:
+- `SKILL.md` frontmatter (`metadata.version`)
+- Plugin's `.claude-plugin/plugin.json`
+
+Run `--update-readme` and `--export-table-row --version <NEW_VERSION>` to update the plugin-level README.md metrics.
+
+## Step 10: Commit (optional)
+
+Ask the user if they want to commit and push:
+1. Stage ONLY the changed files (never `git add .`)
+2. Commit with message: `feat(<plugin>): v<VERSION> — refresh references from upstream sources`
+3. Optionally push and create branch/PR

--- a/plugins/foundry/commands/ss-research.md
+++ b/plugins/foundry/commands/ss-research.md
@@ -27,5 +27,14 @@ Research analyzes:
 - Top-3 improvements with estimated score impact
 - Reference file utilization and coverage gaps
 - Description quality and trigger phrase effectiveness
+- Reference freshness status (if provenance-tracked references exist)
+
+After running the evaluation, check if the skill has provenance-tracked references:
+
+```bash
+uv run ${CLAUDE_PLUGIN_ROOT}/skills/skillsmith/scripts/check_freshness.py $ARGUMENTS --verbose
+```
+
+If provenance exists, include the freshness status in the research output alongside the evaluation metrics. If no provenance exists, skip silently.
 
 Report the findings with specific recommendations for improvement.

--- a/plugins/foundry/skills/skillsmith/SKILL.md
+++ b/plugins/foundry/skills/skillsmith/SKILL.md
@@ -3,7 +3,7 @@ name: skillsmith
 description: This skill should be used when users ask to "create a skill", "validate a skill for quality", "evaluate skill improvements", "improve my skill", "update my skill", "fix skill", "iterate on skill", "optimize skill", "skill quality", "skill performance", "skill isn't working", "analyze skill metrics", "init a new skill", "check skill compliance", or "sync skill to marketplace". Provides comprehensive skill development with automated validation, metrics tracking, and improvement workflows.
 metadata:
   author: J. Greg Williams
-  version: "6.8.0"
+  version: "6.9.0"
 compatibility: Requires python3 and uv for script execution and validation
 license: Complete terms in LICENSE.txt
 ---
@@ -74,6 +74,7 @@ uv run scripts/evaluate_skill.py <skill-path> --explain
 | Spec Compliance | Required and recommended frontmatter fields | Add `metadata.version`, `compatibility`, `license` |
 | Progressive Disclosure | Use of references alongside SKILL.md | Create `references/` for skills >200 lines |
 | Description Quality | Trigger phrase format and specificity | Use action verb phrases ("create X", "fix Y") |
+| Reference Currency | % of provenance-tracked references within staleness threshold | Update stale references, add `last_verified` frontmatter |
 
 See `references/validation_tools_guide.md` for the complete flag reference.
 

--- a/plugins/foundry/skills/skillsmith/references/agentskills_specification.md
+++ b/plugins/foundry/skills/skillsmith/references/agentskills_specification.md
@@ -1,3 +1,15 @@
+---
+last_verified: 2026-04-28
+sources:
+  - type: github
+    repo: "agentskills/agentskills"
+    paths: ["docs/specification.mdx"]
+    description: "Official AgentSkills specification source"
+  - type: web
+    url: "https://agentskills.io/specification"
+    description: "AgentSkills specification web page"
+---
+
 # AgentSkills Specification
 
 This document contains the official AgentSkills specification that defines the structure, requirements, and best practices for creating skills.
@@ -280,6 +292,125 @@ See `references/advanced/subsystem/details.md`
 - Use descriptive, lowercase names with hyphens
 - Match directory structure to purpose
 - Keep filenames concise but clear
+
+## Reference Provenance (Optional)
+
+Reference files can optionally declare where their content originates using YAML frontmatter. This enables automated freshness detection — tools can check whether upstream sources have changed since the reference was last verified.
+
+Provenance is **opt-in**. References without provenance frontmatter are valid and not penalized by evaluation tools.
+
+### Frontmatter Schema
+
+```yaml
+---
+last_verified: 2026-04-28
+sources:
+  - type: web
+    url: "https://docs.example.com/api"
+    description: "Official API documentation"
+  - type: github
+    repo: "org/repo-name"
+    paths: ["src/constants.ts", "docs/"]
+    description: "Source code definitions"
+  - type: gitlab
+    project_id: 12345
+    paths: ["apps/api/routers/v1/"]
+    description: "Engineering API routers"
+  - type: slack
+    channel_id: "C0EXAMPLE"
+    description: "Release announcements channel"
+  - type: plugin
+    name: "obsidian"
+    known_version: "2.1.0"
+    description: "Obsidian CLI plugin capabilities"
+---
+```
+
+### Field Reference
+
+**`last_verified`** (date, required for provenance):
+- ISO 8601 date (`YYYY-MM-DD`) when the reference content was last confirmed accurate against its sources
+- Updated only through the `/ss-refresh` workflow, not manually
+- References older than 90 days (default threshold) are flagged as stale
+
+**`sources`** (list, required for provenance):
+- Each entry has a `type` discriminator and type-specific fields
+- Multiple sources per reference are supported (e.g., a reference summarizing content from both a GitHub repo and a web page)
+
+### Source Types
+
+| Type | Required Fields | Optional Fields | What It Checks |
+|------|----------------|-----------------|----------------|
+| `web` | `url` | `description` | HTTP HEAD status code; URL still reachable |
+| `github` | `repo` | `paths`, `description` | Commits since `last_verified` via `gh api` |
+| `gitlab` | `project_id` | `paths`, `description` | Commits since `last_verified` via `glab api` |
+| `slack` | `channel_id` | `description` | Messages since `last_verified` via Slack API |
+| `plugin` | `name` | `known_version`, `description` | Installed plugin version vs `known_version`; CHANGELOG for new entries |
+
+**`paths`** (for `github` and `gitlab`):
+- List of repository paths to monitor for commits
+- Enables path-level tracking for structured data repos (e.g., tracking `risk-map/schemas/` in a large monorepo)
+- When omitted, checks repo-level commit activity
+
+**`known_version`** (for `plugin`):
+- The plugin version at the time the reference was last verified
+- When the installed plugin version exceeds `known_version`, drift is reported
+
+### Examples
+
+**Web documentation source:**
+```yaml
+---
+last_verified: 2026-04-28
+sources:
+  - type: web
+    url: "https://docs.paloaltonetworks.com/ai-runtime-security"
+    description: "AIRS product documentation"
+---
+```
+
+**GitHub structured data repo:**
+```yaml
+---
+last_verified: 2026-04-28
+sources:
+  - type: github
+    repo: "cosai-oasis/secure-ai-tooling"
+    paths: ["risk-map/schemas/", "risk-map/personas.yaml"]
+    description: "CoSAI Risk Map framework schemas and data"
+---
+```
+
+**Cross-plugin dependency:**
+```yaml
+---
+last_verified: 2026-04-28
+sources:
+  - type: plugin
+    name: "obsidian"
+    known_version: "2.1.0"
+    description: "Obsidian CLI and vault management capabilities"
+---
+```
+
+**Multiple sources on one reference:**
+```yaml
+---
+last_verified: 2026-04-28
+sources:
+  - type: github
+    repo: "cdot65/prisma-airs-sdk"
+    paths: ["src/constants.ts"]
+    description: "SDK API path definitions"
+  - type: web
+    url: "https://docs.paloaltonetworks.com/ai-runtime-security"
+    description: "Product documentation"
+  - type: gitlab
+    project_id: 22949
+    paths: ["apps/data-plane/src/data_plane/api/routers/v1/"]
+    description: "Engineering API routers"
+---
+```
 
 ## Validation
 

--- a/plugins/foundry/skills/skillsmith/references/skill_patterns.md
+++ b/plugins/foundry/skills/skillsmith/references/skill_patterns.md
@@ -1,3 +1,11 @@
+---
+last_verified: 2026-04-28
+sources:
+  - type: web
+    url: "https://www.anthropic.com/engineering/claude-code-best-practices"
+    description: "Anthropic's Complete Guide to Building Skills for Claude"
+---
+
 # Skill Patterns
 
 Five proven behavioral patterns from Anthropic's "Complete Guide to Building Skills for Claude." Use these to choose the right architectural shape for a skill before writing SKILL.md.

--- a/plugins/foundry/skills/skillsmith/references/testing_guide.md
+++ b/plugins/foundry/skills/skillsmith/references/testing_guide.md
@@ -1,3 +1,11 @@
+---
+last_verified: 2026-04-28
+sources:
+  - type: web
+    url: "https://www.anthropic.com/engineering/claude-code-best-practices"
+    description: "Anthropic's Complete Guide to Building Skills for Claude"
+---
+
 # Skill Testing Methodology
 
 Three testing areas defined by Anthropic's "Complete Guide to Building Skills for Claude," adapted for use with skillsmith's automated tooling.

--- a/plugins/foundry/skills/skillsmith/references/validation_tools_guide.md
+++ b/plugins/foundry/skills/skillsmith/references/validation_tools_guide.md
@@ -819,6 +819,91 @@ Description Quality is weighted at 0.10 (10%) in the overall score calculation:
 
 ---
 
+## Reference Currency Score (Opt-in)
+
+Reference Currency is the sixth quality dimension, measuring whether provenance-tracked references are up-to-date with their upstream sources.
+
+### How It Works
+
+- References with YAML frontmatter containing `last_verified` and `sources` are tracked
+- Skills without provenance frontmatter score **100 (neutral)** — no penalty for opting out
+- Score = percentage of tracked references within the staleness threshold (default: 90 days)
+
+### Scoring Model
+
+| Condition | Score |
+|-----------|-------|
+| No provenance frontmatter on any reference | 100 (neutral) |
+| All tracked references within threshold | 100 |
+| Some stale | Proportional reduction |
+| All stale | 0 |
+
+### Weight Distribution (with Reference Currency)
+
+When provenance-tracked references exist, weights are redistributed proportionally:
+
+| Metric | Without Ref Currency | With Ref Currency |
+|--------|---------------------|-------------------|
+| Conciseness | 0.20 | 0.18 |
+| Complexity | 0.20 | 0.18 |
+| Spec Compliance | 0.30 | 0.27 |
+| Progressive Disclosure | 0.20 | 0.18 |
+| Description Quality | 0.10 | 0.09 |
+| Reference Currency | — | 0.10 |
+
+### check_freshness.py
+
+Standalone freshness detection script. Scans `references/` for provenance frontmatter and checks each source for activity since `last_verified`.
+
+```bash
+# Basic freshness report
+uv run scripts/check_freshness.py <skill-path>
+
+# Full audit with all source details
+uv run scripts/check_freshness.py <skill-path> --full-audit --probe --verbose
+
+# Machine-readable JSON output (used by evaluate_skill.py internally)
+uv run scripts/check_freshness.py <skill-path> --format json
+
+# Custom staleness threshold
+uv run scripts/check_freshness.py <skill-path> --threshold-days 60
+```
+
+**Flags:**
+- `--probe` — HTTP-check web source URLs
+- `--full-audit` — Show all source activity regardless of `last_verified` cutoff
+- `--threshold-days N` — Days before a reference is stale (default: 90)
+- `--format json` — Machine-readable JSON output
+- `--since DATE` — Override `last_verified` with a specific date
+- `--verbose` — Detailed per-source check results
+
+### evaluate_skill.py Integration
+
+Reference Currency is calculated automatically when provenance frontmatter is detected:
+
+```bash
+# Included automatically in comprehensive evaluation
+uv run scripts/evaluate_skill.py <skill-path>
+
+# Explicit flag (same result as auto-detection)
+uv run scripts/evaluate_skill.py <skill-path> --check-freshness
+
+# Explain mode shows freshness coaching
+uv run scripts/evaluate_skill.py <skill-path> --explain
+```
+
+### /ss-refresh Command
+
+Guides reference updates for any skill with provenance-tracked references:
+
+```bash
+/ss-refresh <skill-path>
+```
+
+The command runs the freshness checker, presents a report, and on confirmation guides updating stale references from their upstream sources.
+
+---
+
 ## Related References
 
 - `research_guide.md` - Detailed research phase documentation

--- a/plugins/foundry/skills/skillsmith/scripts/check_freshness.py
+++ b/plugins/foundry/skills/skillsmith/scripts/check_freshness.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml"]
+# ///
+"""
+Generic Reference Freshness Checker.
+
+Scans any skill's references/ for provenance frontmatter and reports staleness.
+Checks each source type (web, github, gitlab, slack, plugin) for activity
+since last_verified.
+
+Usage:
+    uv run check_freshness.py [OPTIONS] [SKILL_PATH]
+
+Options:
+    --since DATE         Override last_verified with this date (YYYY-MM-DD)
+    --threshold-days N   Days before a reference is stale (default: 90)
+    --probe              HTTP-check web source URLs
+    --full-audit         Show all source activity regardless of last_verified
+    --format json        Machine-readable JSON output
+    --verbose            Show detailed per-source check results
+
+Output: Markdown freshness report to stdout (or JSON with --format json).
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+from datetime import date, datetime
+from pathlib import Path
+
+
+DEFAULT_THRESHOLD_DAYS = 90
+
+
+def parse_frontmatter(path: Path) -> dict:
+    """Extract YAML frontmatter from a markdown file."""
+    try:
+        text = path.read_text()
+    except (OSError, UnicodeDecodeError):
+        return {}
+    if not text.startswith("---"):
+        return {}
+    try:
+        end = text.index("---", 3)
+    except ValueError:
+        return {}
+    import yaml
+    return yaml.safe_load(text[3:end]) or {}
+
+
+def parse_date(date_val) -> date | None:
+    """Parse date from YAML (may be date object) or string."""
+    if isinstance(date_val, date) and not isinstance(date_val, datetime):
+        return date_val
+    if isinstance(date_val, datetime):
+        return date_val.date()
+    if not isinstance(date_val, str) or not date_val:
+        return None
+    try:
+        return datetime.strptime(date_val.strip(), "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def check_web_source(source: dict) -> dict:
+    """HTTP HEAD check on a web URL. Returns status info."""
+    url = source.get("url", "")
+    if not url:
+        return {"status": "skip", "reason": "no url"}
+    try:
+        result = subprocess.run(
+            ["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
+             "--max-time", "10", "-L", url],
+            capture_output=True, text=True, timeout=15,
+        )
+        code = int(result.stdout.strip())
+        reachable = 200 <= code < 400
+        return {"status": "ok" if reachable else "unreachable", "http_code": code, "url": url}
+    except (subprocess.TimeoutExpired, ValueError, FileNotFoundError):
+        return {"status": "error", "reason": "curl failed or timed out", "url": url}
+
+
+def check_github_source(source: dict, since: date | None = None,
+                        detailed: bool = False) -> dict:
+    """Check GitHub repo activity via gh CLI."""
+    repo = source.get("repo", "")
+    if not repo:
+        return {"status": "skip", "reason": "no repo"}
+
+    paths = source.get("paths", [])
+    result_info: dict = {"status": "ok", "repo": repo, "commits_since": 0,
+                         "latest_commit": None, "changed_files": []}
+
+    try:
+        subprocess.run(["gh", "--version"], capture_output=True, timeout=5)
+    except FileNotFoundError:
+        return {"status": "warn", "reason": "gh CLI not installed", "repo": repo}
+
+    # Check repo-level or path-level commits
+    if since and paths:
+        since_str = since.isoformat()
+        total_commits = 0
+        for path in paths:
+            try:
+                r = subprocess.run(
+                    ["gh", "api",
+                     f"repos/{repo}/commits?since={since_str}T00:00:00Z"
+                     f"&path={path}&per_page=100"],
+                    capture_output=True, text=True, timeout=15,
+                )
+                if r.returncode == 0:
+                    commits = json.loads(r.stdout)
+                    total_commits += len(commits)
+                    if detailed:
+                        for c in commits:
+                            title = c["commit"]["message"].split("\n")[0]
+                            cdate = c["commit"]["committer"]["date"][:10]
+                            result_info["changed_files"].append(
+                                f"{path} — {cdate}: {title}"
+                            )
+            except (subprocess.TimeoutExpired, json.JSONDecodeError, KeyError):
+                pass
+        result_info["commits_since"] = total_commits
+    elif since:
+        since_str = since.isoformat()
+        try:
+            r = subprocess.run(
+                ["gh", "api",
+                 f"repos/{repo}/commits?since={since_str}T00:00:00Z&per_page=1"],
+                capture_output=True, text=True, timeout=15,
+            )
+            if r.returncode == 0:
+                commits = json.loads(r.stdout)
+                result_info["commits_since"] = len(commits)
+        except (subprocess.TimeoutExpired, json.JSONDecodeError):
+            pass
+
+    # Get latest commit date
+    try:
+        r = subprocess.run(
+            ["gh", "api", f"repos/{repo}/commits?per_page=1"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if r.returncode == 0:
+            commits = json.loads(r.stdout)
+            if commits:
+                result_info["latest_commit"] = commits[0]["commit"]["committer"]["date"][:10]
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, KeyError):
+        pass
+
+    return result_info
+
+
+def check_gitlab_source(source: dict, since: date | None = None,
+                        detailed: bool = False) -> dict:
+    """Check GitLab repo activity via glab CLI."""
+    project_id = source.get("project_id")
+    if not project_id:
+        return {"status": "skip", "reason": "no project_id"}
+
+    paths = source.get("paths", [])
+    result_info: dict = {"status": "ok", "project_id": project_id, "commits_since": 0,
+                         "latest_commit": None, "changed_files": []}
+
+    try:
+        subprocess.run(["glab", "--version"], capture_output=True, timeout=5)
+    except FileNotFoundError:
+        return {"status": "warn", "reason": "glab CLI not installed", "project_id": project_id}
+
+    if since and paths:
+        since_str = since.isoformat()
+        total_commits = 0
+        for path in paths:
+            try:
+                r = subprocess.run(
+                    ["glab", "api",
+                     f"projects/{project_id}/repository/commits?since={since_str}T00:00:00Z"
+                     f"&path={path}&per_page=100"],
+                    capture_output=True, text=True, timeout=15,
+                )
+                if r.returncode == 0:
+                    commits = json.loads(r.stdout)
+                    total_commits += len(commits)
+                    if detailed:
+                        for c in commits:
+                            title = c.get("title", "")
+                            cdate = c.get("committed_date", "")[:10]
+                            result_info["changed_files"].append(
+                                f"{path} — {cdate}: {title}"
+                            )
+            except (subprocess.TimeoutExpired, json.JSONDecodeError):
+                pass
+        result_info["commits_since"] = total_commits
+    elif since:
+        since_str = since.isoformat()
+        try:
+            r = subprocess.run(
+                ["glab", "api",
+                 f"projects/{project_id}/repository/commits?since={since_str}T00:00:00Z&per_page=1"],
+                capture_output=True, text=True, timeout=15,
+            )
+            if r.returncode == 0:
+                commits = json.loads(r.stdout)
+                result_info["commits_since"] = len(commits)
+        except (subprocess.TimeoutExpired, json.JSONDecodeError):
+            pass
+
+    try:
+        r = subprocess.run(
+            ["glab", "api", f"projects/{project_id}/repository/commits?per_page=1"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if r.returncode == 0:
+            commits = json.loads(r.stdout)
+            if commits:
+                result_info["latest_commit"] = commits[0].get("committed_date", "")[:10]
+    except (subprocess.TimeoutExpired, json.JSONDecodeError):
+        pass
+
+    return result_info
+
+
+def check_slack_source(source: dict, since: date | None = None) -> dict:
+    """Check Slack channel for messages since last_verified."""
+    channel_id = source.get("channel_id", "")
+    if not channel_id:
+        return {"status": "skip", "reason": "no channel_id"}
+
+    token = os.environ.get("SLACK_USER_TOKEN", "")
+    if not token:
+        return {"status": "warn", "reason": "SLACK_USER_TOKEN not set", "channel_id": channel_id}
+
+    params: dict[str, str | int] = {"channel": channel_id, "limit": 50}
+    if since:
+        params["oldest"] = str(int(datetime.combine(since, datetime.min.time()).timestamp()))
+
+    data = urllib.parse.urlencode(params).encode("utf-8")
+    req = urllib.request.Request(
+        "https://slack.com/api/conversations.history",
+        data=data,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+    )
+
+    body: dict = {}
+    for attempt in range(2):
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                if resp.status == 429:
+                    retry_after = int(resp.headers.get("Retry-After", "5"))
+                    if attempt == 0:
+                        time.sleep(retry_after)
+                        continue
+                    return {"status": "error", "reason": "rate limited", "channel_id": channel_id}
+                body = json.loads(resp.read().decode("utf-8"), strict=False)
+        except Exception as e:
+            return {"status": "error", "reason": str(e), "channel_id": channel_id}
+        break
+
+    if not body.get("ok"):
+        return {"status": "error", "reason": body.get("error", "unknown"), "channel_id": channel_id}
+
+    message_count = sum(
+        1 for msg in body.get("messages", [])
+        if msg.get("subtype") not in ("channel_join", "channel_leave")
+        and msg.get("text", "").strip()
+    )
+
+    return {"status": "ok", "channel_id": channel_id, "messages_since": message_count}
+
+
+def check_plugin_source(source: dict) -> dict:
+    """Check installed plugin version vs known_version."""
+    plugin_name = source.get("name", "")
+    if not plugin_name:
+        return {"status": "skip", "reason": "no plugin name"}
+
+    known_version = source.get("known_version", "")
+    plugins_dir = Path.home() / ".claude" / "plugins"
+
+    # Search installed plugins and cache for matching plugin
+    installed_version = None
+    search_dirs = [plugins_dir]
+    cache_dir = plugins_dir / "cache"
+    if cache_dir.is_dir():
+        search_dirs.append(cache_dir)
+
+    for search_dir in search_dirs:
+        if not search_dir.is_dir():
+            continue
+        for plugin_json in search_dir.rglob("plugin.json"):
+            try:
+                data = json.loads(plugin_json.read_text())
+                if data.get("name", "").lower() == plugin_name.lower():
+                    installed_version = data.get("version", "unknown")
+                    break
+            except (json.JSONDecodeError, OSError):
+                continue
+        if installed_version:
+            break
+
+    if not installed_version:
+        return {"status": "warn", "reason": f"plugin '{plugin_name}' not installed",
+                "plugin": plugin_name}
+
+    drift = False
+    if known_version and installed_version != known_version:
+        drift = True
+
+    return {
+        "status": "drift" if drift else "ok",
+        "plugin": plugin_name,
+        "known_version": known_version or "unset",
+        "installed_version": installed_version,
+    }
+
+
+def scan_skill_references(skill_path: Path) -> list[dict]:
+    """Scan a skill's references/ directory for provenance-tracked files."""
+    refs_dir = skill_path / "references"
+    if not refs_dir.is_dir():
+        return []
+
+    results = []
+    for ref_path in sorted(refs_dir.glob("*.md")):
+        fm = parse_frontmatter(ref_path)
+        last_verified = parse_date(fm.get("last_verified"))
+        sources = fm.get("sources", [])
+
+        if not sources and not last_verified:
+            continue
+
+        results.append({
+            "file": ref_path.name,
+            "path": str(ref_path),
+            "last_verified": last_verified,
+            "sources": sources,
+        })
+
+    return results
+
+
+def check_reference(ref: dict, today: date, threshold_days: int,
+                    since_override: date | None = None,
+                    probe: bool = False, full_audit: bool = False) -> dict:
+    """Check a single reference's freshness against all its sources."""
+    last_verified = ref["last_verified"]
+    since = since_override or last_verified
+
+    age_days = (today - last_verified).days if last_verified else None
+    is_stale = age_days is not None and age_days > threshold_days
+    never_verified = last_verified is None and ref["sources"]
+
+    source_results = []
+    has_activity = False
+
+    for source in ref["sources"]:
+        src_type = source.get("type", "unknown")
+        result: dict = {"type": src_type, "description": source.get("description", "")}
+
+        if src_type == "web":
+            if probe:
+                result.update(check_web_source(source))
+            else:
+                result["status"] = "skipped"
+                result["reason"] = "use --probe to check URLs"
+        elif src_type == "github":
+            result.update(check_github_source(source, since=since, detailed=full_audit))
+            if result.get("commits_since", 0) > 0:
+                has_activity = True
+        elif src_type == "gitlab":
+            result.update(check_gitlab_source(source, since=since, detailed=full_audit))
+            if result.get("commits_since", 0) > 0:
+                has_activity = True
+        elif src_type == "slack":
+            result.update(check_slack_source(source, since=since))
+            if result.get("messages_since", 0) > 0:
+                has_activity = True
+        elif src_type == "plugin":
+            result.update(check_plugin_source(source))
+            if result.get("status") == "drift":
+                has_activity = True
+        else:
+            result["status"] = "unknown"
+            result["reason"] = f"unsupported source type: {src_type}"
+
+        source_results.append(result)
+
+    return {
+        "file": ref["file"],
+        "last_verified": last_verified.isoformat() if last_verified else None,
+        "age_days": age_days,
+        "is_stale": is_stale or never_verified,
+        "never_verified": never_verified,
+        "has_upstream_activity": has_activity,
+        "sources": source_results,
+    }
+
+
+def calculate_freshness_score(results: list[dict]) -> int:
+    """Calculate freshness score as percentage of non-stale tracked references."""
+    if not results:
+        return 100
+    fresh_count = sum(1 for r in results if not r["is_stale"])
+    return int((fresh_count / len(results)) * 100)
+
+
+def format_markdown_report(results: list[dict], score: int, today: date,
+                           threshold_days: int) -> str:
+    """Format results as a markdown freshness report."""
+    lines = [
+        "# Reference Freshness Report",
+        f"\nGenerated: {today}",
+        f"Staleness threshold: {threshold_days} days",
+        f"Freshness score: {score}/100",
+        f"Tracked references: {len(results)}",
+        "",
+    ]
+
+    stale_refs = [r for r in results if r["is_stale"]]
+    fresh_refs = [r for r in results if not r["is_stale"]]
+
+    if stale_refs:
+        lines.append("## Stale References\n")
+        for r in stale_refs:
+            if r["never_verified"]:
+                lines.append(f"- **{r['file']}** — never verified (has sources but no last_verified)")
+            else:
+                lines.append(f"- **{r['file']}** — last verified {r['last_verified']} "
+                             f"({r['age_days']} days ago)")
+        lines.append("")
+
+    if fresh_refs:
+        lines.append("## Fresh References\n")
+        for r in fresh_refs:
+            lines.append(f"- {r['file']} — last verified {r['last_verified']} "
+                         f"({r['age_days']} days ago)")
+        lines.append("")
+
+    activity_refs = [r for r in results if r["has_upstream_activity"]]
+    if activity_refs:
+        lines.append("## Upstream Activity Detected\n")
+        for r in activity_refs:
+            lines.append(f"### {r['file']}\n")
+            for src in r["sources"]:
+                if src.get("commits_since", 0) > 0:
+                    lines.append(f"- **{src['type']}** ({src.get('description', '')}): "
+                                 f"{src['commits_since']} commits since {r['last_verified']}")
+                    for entry in src.get("changed_files", []):
+                        lines.append(f"  - {entry}")
+                elif src.get("messages_since", 0) > 0:
+                    lines.append(f"- **slack** ({src.get('description', '')}): "
+                                 f"{src['messages_since']} messages since {r['last_verified']}")
+                elif src.get("status") == "drift":
+                    lines.append(f"- **plugin** ({src.get('description', '')}): "
+                                 f"installed v{src.get('installed_version')} "
+                                 f"vs known v{src.get('known_version')}")
+            lines.append("")
+
+    # Warnings
+    warnings = []
+    for r in results:
+        for src in r["sources"]:
+            if src.get("status") == "warn":
+                warnings.append(f"- {r['file']}: {src['type']} — {src.get('reason', '')}")
+            elif src.get("status") == "error":
+                warnings.append(f"- {r['file']}: {src['type']} — {src.get('reason', '')}")
+            elif src.get("status") == "unreachable":
+                warnings.append(f"- {r['file']}: web — {src.get('url', '')} "
+                                f"(HTTP {src.get('http_code', '?')})")
+
+    if warnings:
+        lines.append("## Warnings\n")
+        for w in warnings:
+            lines.append(w)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_json_output(results: list[dict], score: int, today: date,
+                       threshold_days: int) -> str:
+    """Format results as JSON for programmatic consumption."""
+    output = {
+        "generated": today.isoformat(),
+        "threshold_days": threshold_days,
+        "score": score,
+        "tracked_references": len(results),
+        "stale_count": sum(1 for r in results if r["is_stale"]),
+        "references": results,
+    }
+    return json.dumps(output, indent=2, default=str)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generic reference freshness checker for AgentSkills"
+    )
+    parser.add_argument("skill_path", nargs="?", default=".",
+                        help="Path to skill directory (default: current directory)")
+    parser.add_argument("--since", type=str, default=None,
+                        help="Override last_verified with this date (YYYY-MM-DD)")
+    parser.add_argument("--threshold-days", type=int, default=DEFAULT_THRESHOLD_DAYS,
+                        help=f"Days before a reference is stale (default: {DEFAULT_THRESHOLD_DAYS})")
+    parser.add_argument("--probe", action="store_true",
+                        help="HTTP-check web source URLs")
+    parser.add_argument("--full-audit", action="store_true",
+                        help="Show all source activity regardless of last_verified cutoff")
+    parser.add_argument("--format", choices=["text", "json"], default="text",
+                        help="Output format (default: text)")
+    parser.add_argument("--verbose", action="store_true",
+                        help="Show detailed per-source check results")
+    args = parser.parse_args()
+
+    skill_path = Path(args.skill_path).resolve()
+
+    # Auto-detect: if given a references/ dir, go up one level
+    if skill_path.name == "references" and skill_path.is_dir():
+        skill_path = skill_path.parent
+
+    # Validate skill path
+    if not (skill_path / "references").is_dir():
+        if args.format == "json":
+            print(json.dumps({"error": f"No references/ directory at {skill_path}",
+                              "score": 100, "tracked_references": 0}))
+        else:
+            print(f"No references/ directory found at {skill_path}", file=sys.stderr)
+            print("Score: 100 (no provenance-tracked references)")
+        sys.exit(0)
+
+    since_override = parse_date(args.since) if args.since else None
+    today = date.today()
+
+    # Scan references
+    tracked_refs = scan_skill_references(skill_path)
+
+    if not tracked_refs:
+        if args.format == "json":
+            print(json.dumps({"score": 100, "tracked_references": 0,
+                              "message": "No provenance-tracked references found"}))
+        else:
+            print("No provenance-tracked references found.")
+            print("Score: 100 (neutral — opt-in provenance not configured)")
+        sys.exit(0)
+
+    if args.verbose:
+        print(f"Found {len(tracked_refs)} provenance-tracked references", file=sys.stderr)
+
+    # Check each reference
+    results = []
+    for ref in tracked_refs:
+        if args.verbose:
+            print(f"  Checking {ref['file']}...", file=sys.stderr)
+        result = check_reference(
+            ref, today, args.threshold_days,
+            since_override=since_override,
+            probe=args.probe,
+            full_audit=args.full_audit,
+        )
+        results.append(result)
+
+    score = calculate_freshness_score(results)
+
+    if args.format == "json":
+        print(format_json_output(results, score, today, args.threshold_days))
+    else:
+        print(format_markdown_report(results, score, today, args.threshold_days))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/foundry/skills/skillsmith/scripts/evaluate_skill.py
+++ b/plugins/foundry/skills/skillsmith/scripts/evaluate_skill.py
@@ -1111,7 +1111,62 @@ def validate_description_quality(frontmatter_dict):
     }
 
 
-def calculate_overall_score(conciseness, complexity, spec_compliance, progressive, description_quality=None):
+def calculate_reference_currency_score(skill_path):
+    """Calculate Reference Currency score by running check_freshness.py.
+
+    Opt-in: returns score 100 (neutral) if no provenance-tracked references exist.
+    """
+    skill_path = Path(skill_path)
+    refs_dir = skill_path / 'references'
+    if not refs_dir.is_dir():
+        return {'score': 100, 'details': 'no references/ directory', 'tracked': 0, 'stale': 0}
+
+    # Check if any reference has provenance frontmatter
+    has_provenance = False
+    for ref_path in refs_dir.glob('*.md'):
+        try:
+            text = ref_path.read_text()
+            if text.startswith('---') and 'last_verified' in text[:500]:
+                has_provenance = True
+                break
+        except (OSError, UnicodeDecodeError):
+            continue
+
+    if not has_provenance:
+        return {'score': 100, 'details': 'no provenance-tracked references (opt-in neutral)',
+                'tracked': 0, 'stale': 0}
+
+    # Run check_freshness.py as subprocess
+    script_dir = Path(__file__).parent
+    freshness_script = script_dir / 'check_freshness.py'
+    if not freshness_script.exists():
+        return {'score': 100, 'details': 'check_freshness.py not found (fallback neutral)',
+                'tracked': 0, 'stale': 0}
+
+    try:
+        result = subprocess.run(
+            [sys.executable, str(freshness_script), str(skill_path), '--format', 'json'],
+            capture_output=True, text=True, timeout=60,
+        )
+        if result.returncode != 0:
+            return {'score': 100, 'details': 'freshness check failed (fallback neutral)',
+                    'tracked': 0, 'stale': 0}
+
+        data = json.loads(result.stdout)
+        return {
+            'score': data.get('score', 100),
+            'details': f"{data.get('tracked_references', 0)} tracked, "
+                       f"{data.get('stale_count', 0)} stale",
+            'tracked': data.get('tracked_references', 0),
+            'stale': data.get('stale_count', 0),
+        }
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, Exception):
+        return {'score': 100, 'details': 'freshness check error (fallback neutral)',
+                'tracked': 0, 'stale': 0}
+
+
+def calculate_overall_score(conciseness, complexity, spec_compliance, progressive,
+                            description_quality=None, reference_currency=None):
     """Calculate weighted overall score
 
     Weights without description quality:
@@ -1126,8 +1181,25 @@ def calculate_overall_score(conciseness, complexity, spec_compliance, progressiv
     - Spec Compliance: 0.30
     - Progressive Disclosure: 0.20
     - Description Quality: 0.10
+
+    Weights with description quality + reference currency:
+    - Conciseness: 0.18
+    - Complexity: 0.18
+    - Spec Compliance: 0.27
+    - Progressive Disclosure: 0.18
+    - Description Quality: 0.09
+    - Reference Currency: 0.10
     """
-    if description_quality:
+    if description_quality and reference_currency and reference_currency.get('tracked', 0) > 0:
+        overall = (
+            conciseness['score'] * 0.18 +
+            complexity['score'] * 0.18 +
+            spec_compliance['score'] * 0.27 +
+            progressive['score'] * 0.18 +
+            description_quality['score'] * 0.09 +
+            reference_currency['score'] * 0.10
+        )
+    elif description_quality:
         overall = (
             conciseness['score'] * 0.20 +
             complexity['score'] * 0.20 +
@@ -2122,6 +2194,8 @@ def store_metrics_in_metadata(skill_path, metrics):
         'overall': metrics['overall_score'],
         'last_evaluated': datetime.now().strftime('%Y-%m-%d')
     }
+    if 'reference_currency' in metrics and metrics['reference_currency'].get('tracked', 0) > 0:
+        metrics_data['reference_currency'] = metrics['reference_currency']['score']
 
     # Build new frontmatter (preserve existing fields)
     new_frontmatter_lines = []
@@ -2196,9 +2270,11 @@ def calculate_all_metrics(skill_path):
         )
     progressive = calculate_progressive_disclosure_score(basic)
     description_quality = validate_description_quality(frontmatter_dict)
-    overall = calculate_overall_score(conciseness, complexity, spec_compliance, progressive, description_quality)
+    reference_currency = calculate_reference_currency_score(skill_path)
+    overall = calculate_overall_score(conciseness, complexity, spec_compliance, progressive,
+                                     description_quality, reference_currency)
 
-    return {
+    result = {
         'skill_name': frontmatter_dict.get('name', skill_path.name),
         'basic_metrics': basic,
         'conciseness': conciseness,
@@ -2206,8 +2282,10 @@ def calculate_all_metrics(skill_path):
         'spec_compliance': spec_compliance,
         'progressive_disclosure': progressive,
         'description_quality': description_quality,
+        'reference_currency': reference_currency,
         'overall_score': overall
     }
+    return result
 
 
 def evaluate_skill(skill_path, compare_with=None, validate_func=False, store_metrics=False, quiet=False):
@@ -2392,6 +2470,8 @@ def print_explain_output(evaluation):
     print(f"  Progressive:     {format_score_bar(metrics['progressive_disclosure']['score'])}")
     if 'description_quality' in metrics:
         print(f"  Description:     {format_score_bar(metrics['description_quality']['score'])}")
+    if 'reference_currency' in metrics and metrics['reference_currency'].get('tracked', 0) > 0:
+        print(f"  Ref Currency:    {format_score_bar(metrics['reference_currency']['score'])}")
     print(f"  Overall:         {format_score_bar(overall)}")
     print()
 
@@ -2634,6 +2714,33 @@ def print_explain_output(evaluation):
                 print("  ✓ Nothing to improve — already at 100")
         print()
 
+    # ── REFERENCE CURRENCY ────────────────────────────────────────────────────
+    if 'reference_currency' in metrics and metrics['reference_currency'].get('tracked', 0) > 0:
+        rc = metrics['reference_currency']
+        rc_score = rc['score']
+        print(f"Reference Currency Score: {rc_score}/100\n")
+        print("  Why:")
+        print(f"    Provenance-tracked references: {rc['tracked']}")
+        print(f"    Stale references: {rc['stale']}")
+        if rc_score == 100:
+            print("    All tracked references are within the staleness threshold")
+        else:
+            print(f"    {rc['stale']} reference(s) exceed the staleness threshold")
+        print()
+        rc_gap = 100 - rc_score
+        if rc_gap > 0:
+            print("  To improve:")
+            print("    - Run /ss-refresh to update stale references from upstream sources")
+            print("    - Update last_verified dates after verifying reference accuracy")
+            print()
+            print("  See: references/validation_tools_guide.md for freshness check details")
+            delta = int(rc_gap * 0.10)
+            if delta > 0:
+                improvements.append((delta, f"Refresh stale references → +{delta} overall"))
+        else:
+            print("  ✓ Nothing to improve — all references fresh")
+        print()
+
     # ── TOP-3 SUMMARY ─────────────────────────────────────────────────────────
     improvements.sort(reverse=True)
     print(f"{'='*60}")
@@ -2673,6 +2780,8 @@ def print_evaluation_text(evaluation):
     print(f"  Progressive:     {format_score_bar(metrics['progressive_disclosure']['score'])}")
     if 'description_quality' in metrics:
         print(f"  Description:     {format_score_bar(metrics['description_quality']['score'])}")
+    if 'reference_currency' in metrics and metrics['reference_currency'].get('tracked', 0) > 0:
+        print(f"  Ref Currency:    {format_score_bar(metrics['reference_currency']['score'])}")
     print(f"  Overall:         {format_score_bar(metrics['overall_score'])}")
     print()
 
@@ -2896,6 +3005,7 @@ def main():
     validate_func = False
     store_metrics_flag = False
     export_table_row = False
+    check_freshness = False
     version_number = None
     issue_number = None
     output_format = 'text'
@@ -2934,6 +3044,9 @@ def main():
             i += 1
         elif arg == '--store-metrics':
             store_metrics_flag = True
+            i += 1
+        elif arg == '--check-freshness':
+            check_freshness = True
             i += 1
         elif arg == '--export-table-row':
             export_table_row = True

--- a/plugins/foundry/skills/skillsmith/scripts/init_skill.py
+++ b/plugins/foundry/skills/skillsmith/scripts/init_skill.py
@@ -271,6 +271,29 @@ Example real reference docs from other skills:
 - product-management/references/context_building.md - Deep-dive on gathering context
 - bigquery/references/ - API references and query examples
 
+## Provenance Tracking (Optional)
+
+If this reference derives from an external source (API docs, GitHub repo, web page),
+add provenance frontmatter to enable automated freshness detection:
+
+```yaml
+---
+last_verified: 2026-01-01
+sources:
+  - type: web
+    url: "https://docs.example.com/api"
+    description: "Official API documentation"
+  - type: github
+    repo: "org/repo-name"
+    paths: ["src/api/"]
+    description: "Source code definitions"
+---
+```
+
+Supported source types: web, github, gitlab, slack, plugin.
+Run `/ss-refresh` to check for upstream changes. See agentskills_specification.md
+for the full provenance spec.
+
 ## When Reference Docs Are Useful
 
 Reference docs are ideal for:


### PR DESCRIPTION
## Summary

- Add reference provenance tracking to the AgentSkills specification — standardized YAML frontmatter (`last_verified`, `sources`) for tracking where reference content originates
- Build `check_freshness.py` generic script that scans any skill's references and reports staleness across 5 source types (`web`, `github`, `gitlab`, `slack`, `plugin`)
- Add Reference Currency as 6th evaluation dimension in `evaluate_skill.py` (opt-in: neutral 100 for skills without provenance)
- Create `/ss-refresh` command for guided reference updates from upstream sources
- Integrate freshness awareness into `ss-improve` and `ss-research` workflows
- Dogfood provenance on foundry's own references and validate against ai-risk-mapper (CoSAI framework tracking)

## Test plan

- [x] `check_freshness.py` runs on skills with and without provenance (outputs correct reports)
- [x] `evaluate_skill.py` shows Reference Currency score for provenance-tracked skills
- [x] Skills without provenance maintain identical scores (opt-in, no penalty)
- [x] Explain mode (`--explain`) includes Reference Currency coaching
- [x] ai-risk-mapper references correctly tracked with `github` source type (path-level)
- [x] Skillsmith self-evaluates at 100/100 across all 6 dimensions
- [x] `--format json` produces valid structured output for programmatic consumption

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)