### PR TITLE
feat(terminal-guru): enrich mise-tooling with DAG model, routing, and freshness

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "terminal-guru",
       "description": "Terminal diagnostics, configuration, and zsh development expert with triage agent and three focused skills",
       "category": "development",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "author": {
         "name": "J. Greg Williams",
         "email": "283704+totallyGreg@users.noreply.github.com"

--- a/plugins/terminal-guru/.agentsmith-baselines.json
+++ b/plugins/terminal-guru/.agentsmith-baselines.json
@@ -4,6 +4,6 @@
     "trigger_effectiveness": 100,
     "system_prompt_quality": 90,
     "coherence": 80,
-    "last_evaluated": "2026-05-01"
+    "last_evaluated": "2026-05-03"
   }
 }

--- a/plugins/terminal-guru/.claude-plugin/plugin.json
+++ b/plugins/terminal-guru/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-guru",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Terminal diagnostics, configuration, zsh development, system observability, environment composition, and mise tooling expert for macOS/Unix systems. Includes an orchestrator agent for diagnostic triage and five focused skills: terminal-emulation (terminfo, Unicode, display), zsh-dev (autoload functions, fpath, testing, performance), signals-monitoring (macOS logging, Unix signals, file watching, notifications), environment-composition (sesh.toml config, claude CLI integration, worktree workflows), and mise-tooling (mise.toml config, task automation, multi-tenant credentials, tool versioning).",
   "author": {
     "name": "J. Greg Williams",

--- a/plugins/terminal-guru/.terminal-guru-profile.local.md
+++ b/plugins/terminal-guru/.terminal-guru-profile.local.md
@@ -1,0 +1,29 @@
+---
+terminal_stack:
+  shell: zsh
+  terminal: ghostty
+  multiplexer: tmux
+  session_manager: sesh
+  env_manager: mise
+  version_manager: mise
+  secret_store: keychainctl
+  package_managers: [homebrew, uv, npm]
+
+preferences:
+  default_task_runner: mise
+  function_location: ~/.zsh/functions
+  mise_task_style: included_files
+  credential_pattern: multi_tenant
+
+versions:
+  mise: ""
+  tmux: ""
+  sesh: ""
+  zsh: ""
+---
+
+## Notes
+
+Terminal stack profile for terminal-guru. The agent reads this to tailor advice
+without re-asking about the user's setup. Update versions and preferences as
+they change. This file is machine-specific and should be gitignored.

--- a/plugins/terminal-guru/README.md
+++ b/plugins/terminal-guru/README.md
@@ -9,6 +9,7 @@ Diagnostic triage and cross-domain routing. Classifies symptoms and routes to th
 
 | Version | Date | Trigger | Prompt | Coherence | Overall |
 |---------|------|---------|--------|-----------|---------|
+| 5.2.0 | 2026-05-03 | 100 | 90 | 80 | 90 |
 | 5.1.0 | 2026-05-01 | 100 | 90 | 80 | 90 |
 
 ### Skill: terminal-emulation
@@ -50,16 +51,38 @@ Development environment composition using sesh, claude CLI, and git worktrees:
 
 ### Skill: mise-tooling
 mise (jdx/mise) configuration, task automation, and environment management:
-- Configuration hierarchy, profiles, and multi-tenant credential patterns
-- Task system (inline, included files, file-based), DRY patterns via shared shell functions
+- Configuration hierarchy, profiles, lifecycle hooks, monorepo support
+- Task system (inline, included files, file-based), DAG execution, task templates
+- DRY patterns via shared shell functions and task inheritance
 - Environment variables with exec() for dynamic secrets (keychainctl, vault)
-- task_config.includes behavior and gotchas
-- Tool version management
+- task_config.includes behavior and gotchas, cross-project sharing
+- Tool version management, watch mode, CLI reference
+- Use case patterns: milestone aggregation, confirmation, cleanup, CI/CD
+
+## Skill: mise-tooling
+
+### Current Metrics
+
+**Score: 91/100** (Good) — 2026-05-03
+
+| Concs | Complx | Spec | Progr | Descr |
+|-------|--------|------|-------|-------|
+| 100 | 80 | 80 | 100 | 100 |
+
+### Version History
+
+| Version | Date | Issue | Summary | Concs | Complx | Spec | Progr | Descr | Score |
+|---------|------|-------|---------|-------|--------|------|-------|-------|-------|
+| 2.0.0 | 2026-05-03 | - | Enriched references: DAG model, task templates, file-based discovery, hooks, monorepo, watch, CLI reference, use case patterns. Freshness metadata on all references. | 100 | 80 | 80 | 100 | 100 | 91 |
+| 1.0.0 | 2026-05-01 | - | Initial release: config hierarchy, task patterns, DRY, multi-tenant credentials, tool versioning | - | - | - | - | - | 90 |
+
+**Metric Legend:** Concs=Conciseness, Complx=Complexity, Spec=Spec Compliance, Progr=Progressive Disclosure, Descr=Description Quality (0-100 scale)
 
 ## Changelog
 
 | Version | Changes |
 |---------|---------|
+| 5.2.0 | Enriched mise-tooling (v2.0.0): DAG model, task templates, file-based discovery, hooks, monorepo, watch, CLI reference, use case patterns. Added zsh-vs-mise routing decision table. Reference freshness metadata (check_freshness.py compatible). Terminal stack profile for self-improvement. |
 | 5.1.0 | Added mise-tooling skill: config, tasks, includes, DRY patterns, multi-tenant credentials. Agent updated with terminal stack model and quality standards. Replaced direnv with mise as primary env manager. |
 | 5.0.0 | Added environment-composition skill: sesh.toml config, claude CLI integration, direnv, worktree workflows, Lens framework |
 | 4.0.0 | Added signals-monitoring skill: unified logging, signals/trap, file watching, notifications |

--- a/plugins/terminal-guru/agents/terminal-guru.md
+++ b/plugins/terminal-guru/agents/terminal-guru.md
@@ -104,6 +104,10 @@ The user's terminal workflow builds in layers — higher layers refine and codif
 
 Each layer builds on the previous. Diagnose from the bottom up: if zsh is broken, nothing above works. If tmux rendering is wrong, sesh sessions look wrong. If env vars aren't resolving, mise tasks fail.
 
+## Terminal Stack Profile
+
+If `.terminal-guru-profile.local.md` exists in the plugin root, load it before routing. It records the user's terminal tools, versions, and preferences. Use it to tailor advice (e.g., skip "install mise" if mise version is known; use the user's preferred task style). Suggest creating it if it does not exist. Suggest updating it when discovering new information about the user's setup.
+
 ## Quality Standards
 
 - ALWAYS diagnose from the bottom of the terminal stack upward before routing
@@ -166,10 +170,35 @@ Each layer builds on the previous. Diagnose from the bottom up: if zsh is broken
 | DRY mise tasks, shared auth pattern | mise-tooling | - |
 | mise + sesh integration | mise-tooling | environment-composition |
 | mise exec() with keychainctl | mise-tooling | zsh-dev |
+| Should this be a function or a task? | (see Zsh Function vs Mise Task) | - |
+| Automate a workflow, codify a pattern | mise-tooling | zsh-dev |
 
 **Routing guidance for sesh/tmux overlap:** Route to environment-composition when the user wants to compose environments, configure sesh.toml, or combine sesh with claude CLI/direnv/worktrees. Route to terminal-emulation when the issue is about interactive tmux/sesh usage (keybindings, display, pane logging).
 
 **Routing guidance for mise:** Route to mise-tooling for all mise configuration, tasks, environment variables, and tool version management. mise has replaced direnv as the primary environment variable manager — they conflict on PATH management, and mise handles env vars natively. If a user mentions direnv, check whether mise would be the better solution. Route mise + sesh integration to both mise-tooling (for the mise config side) and environment-composition (for the sesh session side).
+
+## Zsh Function vs Mise Task Decision
+
+When a user wants to automate a terminal operation, route to the correct skill:
+
+| Factor | Zsh Function (zsh-dev) | Mise Task (mise-tooling) |
+|--------|----------------------|------------------------|
+| Scope | Personal workflow, single machine | Project-scoped, team-shareable |
+| Shell context | Needs current shell (cd, export, alias) | Subprocess (isolated env) |
+| Interactivity | Completions, widgets, prompt integration | CLI arg parsing via `usage` field |
+| Dependencies | Standalone or sources other functions | DAG-based dependency chains |
+| Environment | Inherits current shell env | Isolated env from mise.toml |
+| Portability | Tied to zsh + user's fpath | Cross-shell, cross-platform |
+| Complexity | Single operation or pipeline | Multi-step workflow |
+| State | Modifies current shell state | Produces artifacts/outputs |
+
+**Decision shortcuts:**
+- "I need this in my shell" → zsh function
+- "The team needs to run this" → mise task
+- "This modifies my working directory or exports" → zsh function
+- "This has build steps that depend on each other" → mise task
+- "I want tab completion" → zsh function (compdef) OR mise task (usage field)
+- "This needs secrets from keychain" → either (keychainctl for zsh, exec() for mise)
 
 ## Mise Tooling Routing
 
@@ -178,7 +207,9 @@ When users request mise configuration, task creation, or environment setup:
 2. Load `references/mise_config_guide.md` for configuration and env patterns
 3. Load `references/mise_task_patterns.md` for task creation, includes, and DRY patterns
 4. Load `references/mise_environment_management.md` for multi-tenant credential management
-5. For mise + sesh integration, also check environment-composition references
+5. Load `references/mise_cli_reference.md` for CLI command lookups
+6. Load `references/mise_use_case_patterns.md` for reusable automation patterns
+7. For mise + sesh integration, also check environment-composition references
 
 ## Diagnostic Process
 

--- a/plugins/terminal-guru/skills/mise-tooling/SKILL.md
+++ b/plugins/terminal-guru/skills/mise-tooling/SKILL.md
@@ -2,7 +2,7 @@
 name: mise-tooling
 description: This skill should be used when the user asks to "configure mise.toml", "create a mise task", "set up tool versions", "manage environments with mise", "debug mise config", "task_config includes", "mise task DRY", "mise profiles", "mise env not loading", "create mise run command", or needs help with mise (jdx/mise) for tool versioning, environment variables, or task automation. Also trigger on mentions of mise.toml, .miserc.toml, mise run, mise env, mise tasks, mise profiles, task_config, or exec() in env. Do NOT use for shell configuration or function generation (use zsh-dev instead). Do NOT use for sesh/tmux session management (use environment-composition instead). Do NOT use for signal handling or logging (use signals-monitoring instead). Mise + sesh integration questions should route here for the mise side and environment-composition for the sesh side.
 metadata:
-  version: "1.0.0"
+  version: "2.0.0"
 ---
 
 # Mise Tooling
@@ -16,12 +16,14 @@ When helping with mise, prefer outputting `mise.toml` config snippets. Always ch
 ## When to Use This Skill
 
 - Writing or modifying `mise.toml` / `.mise.toml` configurations
-- Creating tasks (inline TOML, included files, or file-based)
+- Creating tasks (inline TOML, included files, or file-based scripts)
 - Setting up `[env]` with dynamic values (`exec()`, `_.source`, `_.file`)
 - Organizing tasks across multiple files with `task_config.includes`
 - Debugging environment variable resolution or profile switching
 - Setting up multi-tenant credential management with profiles
 - DRY patterns for shared task logic across projects
+- Task templates and inheritance for reusable definitions
+- Looking up mise CLI commands and flags
 
 ## Core Capabilities
 
@@ -29,13 +31,13 @@ When helping with mise, prefer outputting `mise.toml` config snippets. Always ch
 
 mise walks UP the directory tree — child projects inherit parent configs. This enables shared tasks at the workspace root with project-specific overrides.
 
-See `references/mise_config_guide.md` for the full configuration hierarchy, file precedence, profile loading order, and `[env]` patterns.
+See `references/mise_config_guide.md` for the full configuration hierarchy, file precedence, profile loading order, `[env]` patterns, lifecycle hooks, monorepo support, and secret handling.
 
 ### 2. Task System
 
-Tasks are the most powerful feature — they turn complex workflows into `mise run <name>` commands. Tasks can be defined inline in `mise.toml`, in separate included files, or as executable scripts in `mise-tasks/`.
+Tasks are the most powerful feature — they turn complex workflows into `mise run <name>` commands. Tasks can be defined inline in `mise.toml`, in separate included files, or as executable scripts in `mise-tasks/`. mise builds a DAG from task dependencies and executes independent tasks in parallel.
 
-See `references/mise_task_patterns.md` for task organization, `task_config.includes` behavior (critical gotchas), DRY patterns, and the `usage` field for CLI arg parsing.
+See `references/mise_task_patterns.md` for task organization, `task_config.includes` behavior (critical gotchas), DRY patterns, task templates/inheritance, DAG execution model, visibility controls, output caching, and the `usage` field for CLI arg parsing.
 
 ### 3. Environment Management
 
@@ -54,12 +56,17 @@ uv = "latest"
 
 Multiple versions, per-tool postinstall hooks, and backends (npm, pipx, GitHub releases, aqua).
 
+### 5. Watch Mode & Hooks
+
+Continuous file watching (`mise watch`) for rebuild-on-change workflows. Lifecycle hooks (`[hooks]`) for enter/leave/cd events. See `references/mise_config_guide.md`.
+
 ## Common Workflows
 
 ### "Create a new task"
 1. For simple tasks, add inline to `[tasks]` in `mise.toml`
 2. For service-grouped tasks, create `tasks/<service>.toml` and include via `task_config.includes`
 3. For complex tasks, use `usage` field for arg parsing and `depends` for ordering
+4. For reusable patterns, define `[task_templates.*]` and use `extends`
 
 ### "Share tasks across projects"
 1. Define tasks in a parent directory's `mise.toml` or `tasks/` directory
@@ -72,16 +79,25 @@ Multiple versions, per-tool postinstall hooks, and backends (npm, pipx, GitHub r
 3. Cloners use `_.source = ".env"` for simple credential files
 4. Switch tenants: `MISE_ENV=other mise run <task>`
 
+### "Look up a CLI command"
+See `references/mise_cli_reference.md` for compact command tables covering task management, run flags, environment, and tool operations.
+
+### "Apply a proven automation pattern"
+See `references/mise_use_case_patterns.md` for milestone aggregation, hardware discovery, interactive confirmation, post-task cleanup, CI/CD adaptation, and cross-project task sharing decision trees.
+
 ## Resources
 
 ### references/
-- **`mise_config_guide.md`** — Configuration hierarchy, precedence, env patterns, exec()
-- **`mise_task_patterns.md`** — Task organization, includes, DRY patterns, usage field
+- **`mise_config_guide.md`** — Configuration hierarchy, precedence, env patterns, exec(), hooks, monorepo, settings
+- **`mise_task_patterns.md`** — Task organization, includes, DRY patterns, DAG model, templates, visibility, caching, usage field
 - **`mise_environment_management.md`** — Multi-tenant credentials, profiles, keychain integration
+- **`mise_cli_reference.md`** — CLI commands, run flags, task listing, environment and tool management
+- **`mise_use_case_patterns.md`** — Milestone aggregation, hardware discovery, confirmation, cleanup, CI/CD, cross-project sharing
 
 ### Cross-references
 - **environment-composition** `sesh_config_guide.md` — sesh + mise integration for dev environments
 - **zsh-dev** — Shell function patterns that complement mise tasks
+- **signals-monitoring** — `fswatch`/`entr` for simpler file watching (vs `mise watch`)
 
 ### External
 - [mise documentation](https://mise.jdx.dev/)

--- a/plugins/terminal-guru/skills/mise-tooling/references/mise_cli_reference.md
+++ b/plugins/terminal-guru/skills/mise-tooling/references/mise_cli_reference.md
@@ -1,0 +1,90 @@
+---
+last_verified: 2026-05-03
+sources:
+  - type: web
+    url: "https://mise.jdx.dev/cli/"
+    description: "Official mise CLI documentation"
+  - type: github
+    repo: "jdx/mise"
+    paths: ["docs/cli/"]
+    description: "mise documentation source for CLI commands"
+---
+
+# Mise CLI Reference
+
+## Task Management
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `mise run <TASK> [ARGS...]` | `mise r <TASK>` / `mise <TASK>` | Run a task with optional args |
+| `mise tasks ls` | `mise tasks` / `mise task list` | List all discovered tasks |
+| `mise tasks info <TASK>` | — | Show task metadata (`--json` for machine output) |
+| `mise tasks edit <TASK>` | — | Open task source file in `$EDITOR` |
+| `mise tasks add` | — | Add a new task definition interactively |
+| `mise tasks deps <TASK>` | — | Print dependency graph (DOT format) |
+| `mise tasks validate` | — | Validate task definitions against schema |
+
+## Run Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--jobs` | `-j` | Max concurrent workers (default: 4) |
+| `--continue-on-error` | `-c` | Continue dependents even if a dep fails |
+| `--dry-run` | `-n` | Print execution plan without running |
+| `--force` | `-f` | Force re-execution, bypass cache |
+| `--fresh-env` | — | Bypass cached env state |
+| `--no-cache` | — | Skip all caching for this run |
+| `--skip-deps` | — | Don't run dependency tasks |
+| `--skip-tools` | — | Don't auto-install tools before running |
+| `--timeout` | — | Set max execution time per task |
+| `--timings` | — | Show timing for each task |
+| `--yes` | `-y` | Auto-confirm interactive prompts |
+
+## Task Listing Flags
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Show global, system, and project tasks |
+| `--hidden` | Include normally hidden tasks |
+| `--json` | JSON output |
+| `--extended` | Extra columns (aliases, source file) |
+| `--common` | Only tasks common across subdirectories |
+
+## Parallel Execution
+
+```bash
+mise run build ::: test ::: lint    # run 3 tasks in parallel
+mise run --jobs 8 build test lint   # parallel with job limit
+mise run --timings build test       # show per-task timing
+```
+
+## Environment & Configuration
+
+| Command | Description |
+|---------|-------------|
+| `mise env` | Show resolved environment variables |
+| `mise cfg` | Show loaded config files and precedence |
+| `mise set KEY=value` | Set an environment variable |
+| `mise trust [FILE]` | Trust a config file for execution |
+| `mise doctor` | Comprehensive health check |
+
+## Tool Management
+
+| Command | Description |
+|---------|-------------|
+| `mise install` | Install all configured tools |
+| `mise install <TOOL>@<VERSION>` | Install a specific tool version |
+| `mise ls` | List installed tools |
+| `mise use <TOOL>@<VERSION>` | Pin a tool version in config |
+| `mise outdated` | Check for outdated tools |
+| `mise prune` | Remove unused tool versions |
+
+## Watch Mode
+
+```bash
+mise watch <TASK> -w <PATH>         # watch paths and re-run on change
+mise watch <TASK> --restart         # restart long-running processes
+mise watch build -w src -w Cargo.toml
+```
+
+Requires `watchexec` utility.

--- a/plugins/terminal-guru/skills/mise-tooling/references/mise_config_guide.md
+++ b/plugins/terminal-guru/skills/mise-tooling/references/mise_config_guide.md
@@ -1,3 +1,15 @@
+---
+last_verified: 2026-05-03
+sources:
+  - type: web
+    url: "https://mise.jdx.dev/configuration/"
+    description: "Official mise configuration documentation"
+  - type: github
+    repo: "jdx/mise"
+    paths: ["docs/configuration/"]
+    description: "mise documentation source for configuration"
+---
+
 # Mise Configuration Guide
 
 ## Configuration Hierarchy
@@ -100,14 +112,103 @@ python = ["3.11", "3.12"]
 node = { version = "22", postinstall = "corepack enable" }
 ```
 
-## Settings
+## Lifecycle Hooks
 
-Global settings go in `~/.config/mise/config.toml`:
+Hooks trigger at workspace lifecycle events:
+
+```toml
+[hooks.enter]
+run = "echo 'Welcome to the project'"
+
+[hooks.leave]
+run = "echo 'Goodbye'"
+
+[hooks.cd]
+run = "echo 'Changed to {{cwd}}'"
+```
+
+Available hook points:
+- **`enter`** — triggered when entering the workspace directory
+- **`leave`** — triggered when leaving the workspace
+- **`cd`** — triggered on every directory change within the workspace
+- **`watch`** — file watch listeners that activate when tracked paths update
+
+Hooks run in the shell context with full access to `[env]` variables. The `{{cwd}}` template resolves to the current working directory at hook execution time.
+
+## Monorepo Support
+
+mise supports multi-directory projects with special path syntax:
+
+```toml
+# Reference tasks from monorepo root
+[tasks.build-all]
+depends = ["//frontend:build", "//backend:build"]
+run = "echo 'All packages built'"
+
+# Declare sub-project config locations
+[monorepo]
+config_roots = ["packages/*", "apps/*"]
+```
+
+- **`//` prefix** — resolves from monorepo root, not current directory
+- **`:` separator** — `//projects/frontend:build` targets a specific sub-project task
+- **`*` wildcards** — match across directories and task names
+- **`config_roots`** — declares where mise should discover sub-project configs
+- **Subdirectory scripts** — auto-prefix with directory path (e.g., `web:test`)
+
+## Secret Handling
 
 ```toml
 [settings]
+# Mask sensitive variable names in logs (supports globs)
+redactions = ["*_SECRET", "*_KEY", "*_TOKEN", "CREDENTIALS_*"]
+```
+
+Individual env vars can also be redacted:
+
+```toml
+[env]
+API_KEY = { value = "secret123", redact = true }
+```
+
+The `redactions` setting works with patterns — any env var matching the glob is masked in `mise env` output and logs.
+
+## Task-Related Settings
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `task.jobs` | 4 | Max concurrent workers for parallel task execution |
+| `task.output` | `"prefix"` | Log format: `prefix`, `interleave`, or custom |
+| `task.timeout` | — | Default timeout for all tasks (seconds) |
+| `task_timing` | false | Show timing for every task by default |
+| `task_auto_install` | true | Auto-install tools needed by tasks before running |
+
+Configure globally in `~/.config/mise/config.toml` or per-project in `mise.toml`:
+
+```toml
+[settings]
+task_timing = true
 color = true
 color_theme = "default"  # default/charm (dark), base16 (light), catppuccin, dracula
 ```
 
-The `color_theme` setting controls the interactive TUI picker (`mise run` with no args). The `color = false` setting only affects CLI output, not the interactive picker.
+## Watch Mode
+
+Continuous file watching for rebuild-on-change workflows:
+
+```bash
+mise watch build -w src -w Cargo.toml    # rebuild when files change
+mise watch build --restart               # restart long-running process on change
+mise watch test -w "src/**/*.py"         # glob pattern for watched paths
+```
+
+Requires the `watchexec` utility. For simpler file watching needs (single command, no task DAG), consider `entr` or `fswatch` via the signals-monitoring skill.
+
+## Diagnostics
+
+```bash
+mise cfg        # show loaded config files and precedence
+mise env        # show resolved environment variables
+mise doctor     # comprehensive health check
+mise trust      # trust a config file (required for untrusted sources)
+```

--- a/plugins/terminal-guru/skills/mise-tooling/references/mise_environment_management.md
+++ b/plugins/terminal-guru/skills/mise-tooling/references/mise_environment_management.md
@@ -1,3 +1,15 @@
+---
+last_verified: 2026-05-03
+sources:
+  - type: web
+    url: "https://mise.jdx.dev/environments/"
+    description: "Official mise environments documentation"
+  - type: github
+    repo: "jdx/mise"
+    paths: ["docs/environments/"]
+    description: "mise documentation source for environments"
+---
+
 # Mise Environment Management
 
 ## Multi-Tenant Credential Pattern

--- a/plugins/terminal-guru/skills/mise-tooling/references/mise_task_patterns.md
+++ b/plugins/terminal-guru/skills/mise-tooling/references/mise_task_patterns.md
@@ -1,3 +1,15 @@
+---
+last_verified: 2026-05-03
+sources:
+  - type: web
+    url: "https://mise.jdx.dev/tasks/"
+    description: "Official mise task documentation"
+  - type: github
+    repo: "jdx/mise"
+    paths: ["docs/tasks/"]
+    description: "mise documentation source for tasks"
+---
+
 # Mise Task Patterns
 
 ## Defining Tasks
@@ -42,7 +54,28 @@ run = "curl -sf ..."
 
 ### File-based tasks
 
-Place executable scripts in `mise-tasks/` or `.mise/tasks/`. mise discovers them automatically by filename.
+Place executable scripts in any of these auto-discovered directories:
+
+- `mise-tasks/`
+- `.mise-tasks/`
+- `mise/tasks/`
+- `.mise/tasks/`
+- `.config/mise/tasks/`
+
+Scripts in subdirectories get auto-prefixed: `mise-tasks/build/docker.sh` becomes task `build:docker`. The special filename `_default` strips the suffix.
+
+Add metadata via `#MISE` comment directives at the top of scripts:
+
+```bash
+#!/usr/bin/env bash
+#MISE description="Discover Talos endpoints"
+#MISE depends=["vm:start"]
+#MISE env={CLUSTER="bee3"}
+#MISE sources=["src/**"]
+nmap -p 50000 10.0.0.0/24
+```
+
+Supports any shebang: bash, node, python, deno, powershell.
 
 ## Task Namespacing
 
@@ -56,6 +89,32 @@ hol:build          hol:dev           hol:restart
 ```
 
 Convention: `<service>:<action>` — the service prefix groups related operations.
+
+## Core Task Properties
+
+| Property | Type | Purpose |
+|----------|------|---------|
+| `run` | string / array | Command(s) to execute. Arrays run sequentially. |
+| `run_windows` | string | Windows-specific override. |
+| `description` | string | Shown in `mise tasks --extended` and completions. |
+| `alias` / `aliases` | string / array | Alternative invocation names. |
+| `depends` | string / array | Prerequisites that must succeed first. Forms DAG edges. |
+| `depends_post` | string / array | Runs after parent completes regardless of success. |
+| `wait_for` | string / array | Soft dependency — pauses until target completes but doesn't fail if target failed. |
+| `dir` | string | Working directory override. `{{cwd}}` for caller's CWD. |
+| `shell` | string | Override interpreter (e.g., `"bash"`, `"fish"`). |
+| `tools` | object | Per-task tool installs (e.g., `{rust = "1.80"}`). Auto-installed before run. |
+| `env` | object | Task-level env vars. NOT propagated to dependencies. |
+| `confirm` | string | Interactive prompt before running. Supports Tera templates. |
+| `hide` | bool | Hide from `mise tasks` listing and completions. |
+| `quiet` | bool | Suppress "running: \<command\>" header. |
+| `silent` | bool / string | Mute stdout/stderr. Value can target `"stdout"` or `"stderr"`. |
+| `raw` | bool | Direct I/O passthrough. Breaks parallelism. |
+| `interactive` | bool | Exclusive stdio lock — blocks other tasks. |
+| `raw_args` | bool | Bypass argument parsing, forward inputs verbatim. |
+| `sources` | array | Input file globs for freshness checking. |
+| `outputs` | array | Output file globs. `{ auto = true }` for hash-based cache. |
+| `no_output_cache` | bool | Disable output caching for this task. |
 
 ## vars (Task-Scoped Variables)
 
@@ -81,6 +140,70 @@ run = "mise run hol:run"
 
 **Limitation:** `depends` tasks run in separate processes. Environment variables and shell `export` statements do NOT leak between them. Each task's `env` is scoped to that task only.
 
+## DAG Execution Model
+
+mise builds a **Directed Acyclic Graph** from all task dependencies:
+
+1. Resolve full DAG from task definitions
+2. Topological sort to determine execution order
+3. Launch independent tasks in parallel (up to `task.jobs`, default 4)
+4. When a task completes, check if dependents are now unblocked
+5. `depends_post` runs after the entire graph settles
+
+Key behaviors:
+- **Shared dependencies run once** — if both `test:unit` and `test:integration` depend on `build`, `build` runs only once
+- **`depends`**: prerequisite must **succeed** before dependent runs
+- **`depends_post`**: cleanup runs **after** parent regardless of outcome
+- **`wait_for`**: soft sync — waits but doesn't fail if target failed
+
+```bash
+mise run build ::: test ::: lint   # parallel execution
+mise run --jobs 8 build test lint  # parallel with job limit
+mise tasks deps <task>             # print dependency graph (DOT format)
+mise run --dry-run <task>          # show execution plan without running
+```
+
+## Task Templates & Inheritance
+
+Reusable task definitions via `[task_templates.*]` and the `extends` property:
+
+```toml
+[task_templates.python:test]
+run = "pytest"
+tools = { python = "3.12" }
+
+[tasks.api-test]
+extends = "python:test"
+env = { API_URL = "http://localhost:8080" }
+```
+
+**Merge rules for `extends`:**
+
+| Property | Strategy |
+|----------|----------|
+| `run` / `run_windows` | **Replaces** (never merged) |
+| `depends` | **Replaces** (not accumulated) |
+| `env` | **Deep merge** (template env preserved) |
+| `tools` | **Deep merge** |
+| `dir` / `description` / `shell` | **Does not inherit** — must redefine |
+
+## Output Caching & Incremental Builds
+
+Make-like skip logic: when all `outputs` are newer than all `sources`, the task is skipped entirely.
+
+```toml
+[tasks.build]
+sources = ["src/**/*.rs", "Cargo.toml"]
+outputs = ["target/release/myapp"]
+run = "cargo build --release"
+```
+
+- `sources` — input file globs (changes trigger rebuild)
+- `outputs` — output file globs; `{ auto = true }` uses hash-based cache keys
+- `no_output_cache = true` — bypass caching for this task
+- `mise run --force` — force re-execution regardless of cache
+- `mise run --no-cache` — skip all caching for this run
+
 ## DRY Pattern: Shared Shell Functions
 
 For logic shared across tasks (e.g., OAuth token fetch), define helper functions in a script and source them per-task:
@@ -104,11 +227,11 @@ Then in each task:
 
 ```toml
 ["redteam:targets"]
-run = """
+run = '''
 source "{{config_root}}/scripts/sase-token.sh"
 ACCESS_TOKEN=$(sase_token) || exit 1
 curl -sf "$API_BASE/targets" -H "Authorization: Bearer $ACCESS_TOKEN" | jq '.'
-"""
+'''
 ```
 
 `{{config_root}}` resolves to the directory of the `mise.toml` that defined the task — critical for tasks inherited by child projects.
@@ -130,6 +253,13 @@ run = "model-security scan --model-path {{arg(name='model_path')}}"
 
 Access parsed values via `$usage_<name>` in the `run` script.
 
+**Advanced patterns:**
+- `<arg>` — mandatory positional argument
+- `[arg]` — optional positional argument
+- `${usage_var?}` — error if variable not set
+- `${usage_var:-default}` — default value (non-mutating)
+- Template functions: `{{arg(name='x')}}`, `{{option(name='x')}}`, `{{flag(name='x')}}`
+
 ## Running Tasks
 
 ```bash
@@ -138,12 +268,25 @@ mise run test -- --verbose  # pass extra args after --
 mise run build ::: test     # parallel execution
 mise run --jobs 8 build     # parallel with job limit
 mise run --skip-deps deploy # skip dependency tasks
+mise run --timings build    # show timing per task
+mise run --timeout 60 test  # set max execution time
+mise run --yes deploy       # auto-confirm prompts
 mise tasks                  # list all available tasks
+mise tasks info <task>      # show task metadata
 ```
 
-## Other Features
+## TOML String Gotcha
 
-- `confirm = "Are you sure?"` — prompt before destructive tasks
-- `raw = true` — for interactive tasks that need stdin
-- `sources` / `outputs` — make-like skip logic (only runs if sources newer than outputs)
-- `depends_post` — tasks to run after this task completes
+Always use TOML literal multiline strings (`'''`) for `run` blocks. Basic multiline strings (`"""`) process backslash escapes, breaking jq (`\(.field)`), heredocs, and other shell constructs:
+
+```toml
+# WRONG — breaks jq
+run = """
+  jq -r '"result: \(.id)"'
+"""
+
+# CORRECT — content reaches bash verbatim
+run = '''
+  jq -r '"result: \(.id)"'
+'''
+```

--- a/plugins/terminal-guru/skills/mise-tooling/references/mise_use_case_patterns.md
+++ b/plugins/terminal-guru/skills/mise-tooling/references/mise_use_case_patterns.md
@@ -1,0 +1,165 @@
+---
+last_verified: 2026-05-03
+sources:
+  - type: web
+    url: "https://mise.jdx.dev/tasks/"
+    description: "Official mise task documentation"
+  - type: github
+    repo: "jdx/mise"
+    paths: ["docs/tasks/"]
+    description: "mise documentation source for task patterns"
+---
+
+# Mise Use Case Patterns
+
+Reusable patterns for common task automation scenarios. Each pattern shows the mise.toml structure and explains when to apply it.
+
+## Milestone Aggregation
+
+Meta-tasks that chain domain-specific work into milestone targets. Each milestone `depends` on its prerequisites, forming a progressive deployment pipeline.
+
+```toml
+[tasks."cluster:up"]
+description = "Zero to running k8s cluster"
+depends = ["cluster:nodes", "cluster:network"]
+
+[tasks."cluster:network"]
+description = "Gateway + cert-manager + HTTPS"
+depends = ["cluster:up"]
+
+[tasks."cluster:storage"]
+description = "NFS + iSCSI provisioners"
+depends = ["cluster:network"]
+```
+
+**When to use:** Multi-phase infrastructure or deployment pipelines where later phases build on earlier ones. `mise run cluster:storage` automatically runs everything from scratch.
+
+## Hardware Discovery Workflow
+
+Tasks with dependencies plus a manual checkpoint where the user sets an environment variable between steps:
+
+```toml
+[tasks."vm:start"]
+description = "Start virtual machine"
+run = "qemu-system-x86_64 ..."
+
+[tasks."vm:discover"]
+description = "Scan for VM IP address"
+depends = ["vm:start"]
+run = "nmap -p 50000 10.0.0.0/24"
+
+[tasks."talos:apply"]
+description = "Apply Talos config (requires TALOS_ENDPOINT)"
+env = { TALOS_ENDPOINT = { required = true, help = "Set to discovered IP" } }
+run = "talosctl apply-config --nodes $TALOS_ENDPOINT ..."
+```
+
+**When to use:** Workflows where an intermediate step produces output that a human must inspect and feed forward. The `required = true` env var forces the user to set it before the next phase runs.
+
+## Interactive Confirmation
+
+Protect destructive operations with `confirm`:
+
+```toml
+[tasks."cluster:destroy"]
+description = "Full cluster teardown"
+confirm = "WARNING: This will destroy the entire cluster. Type YES to proceed:"
+run = "./scripts/destroy.sh"
+
+[tasks."db:drop"]
+description = "Drop database"
+confirm = "This will delete all data in {{vars.db_name}}. Continue?"
+run = "dropdb {{vars.db_name}}"
+```
+
+The `confirm` field supports Tera templates — reference `{{vars.*}}` or env vars in the prompt. In CI, use `mise run --yes <task>` to auto-confirm.
+
+**When to use:** Any task that deletes data, tears down infrastructure, or has irreversible side effects.
+
+## Post-Task Cleanup
+
+Use `depends_post` for cleanup that must run regardless of task success:
+
+```toml
+[tasks.deploy]
+description = "Deploy to staging"
+depends = ["build", "test"]
+depends_post = ["cleanup:artifacts"]
+run = "kubectl apply -f manifest.yaml"
+
+[tasks."cleanup:artifacts"]
+description = "Remove build artifacts"
+hide = true
+run = "rm -rf dist/ .build-cache/"
+```
+
+`depends_post` tasks run **after** the parent completes — even if the parent fails. The cleanup task is `hide = true` since it's not meant to be invoked directly.
+
+**When to use:** Temporary files, docker containers, test fixtures, or staging environments that must be cleaned up.
+
+## CI/CD Adaptation
+
+Use profiles to change task behavior between local and CI environments:
+
+```toml
+# mise.toml — base tasks
+[tasks.test]
+run = "pytest --tb=short"
+
+[tasks.deploy]
+run = "./scripts/deploy.sh"
+confirm = "Deploy to production?"
+```
+
+```toml
+# mise.ci.toml — CI overrides
+[tasks.test]
+run = "pytest --tb=long --junitxml=results.xml"
+
+[tasks.deploy]
+run = "./scripts/deploy.sh"
+# No confirm in CI — auto-approved via pipeline
+```
+
+Activate with `MISE_ENV=ci` in the CI runner. The CI profile overrides base tasks without modifying the shared config.
+
+**When to use:** Different output formats, stricter checks, or removed interactive prompts in CI.
+
+## Cross-Project Task Sharing
+
+Two patterns for sharing tasks across projects — choose based on your needs:
+
+### Parent Directory Inheritance
+
+mise walks up the directory tree automatically. Tasks in a parent config are available in all child projects:
+
+```
+workspace/.mise.toml          # defines auth:check, scan:all
+└── project-a/.mise.toml      # defines build, test
+    $ mise tasks              # shows BOTH parent and project tasks
+└── project-b/.mise.toml
+    $ mise tasks              # same parent tasks, different project tasks
+```
+
+**Use when:** Projects are co-located in a workspace directory and share operational tasks (auth, scanning, deployment).
+
+### task_config.includes
+
+Pull task files from a specific location:
+
+```toml
+[task_config]
+includes = [
+  "../shared-tasks/auth.toml",
+  "../shared-tasks/deploy.toml",
+]
+```
+
+**Use when:** Task files live in a separate repo or non-parent directory. Remember: must list files explicitly (directory globs silently fail).
+
+### Decision tree
+
+1. Are projects in the same workspace? → Parent inheritance (simpler, automatic)
+2. Are tasks in a separate repo? → `task_config.includes` with explicit paths
+3. Need per-project task overrides? → Child config redefines the task (same name wins)
+4. Need tasks that reference project-local files? → Use `{{config_root}}` for portability


### PR DESCRIPTION
## Summary
- Enriched mise-tooling skill (v1.0.0 → v2.0.0) with DAG execution model, task templates/inheritance, file-based discovery, lifecycle hooks, monorepo support, watch mode, CLI reference, and use case patterns from vault research
- Added zsh-function-vs-mise-task routing decision table to the agent for cross-domain automation decisions
- Added provenance frontmatter (`last_verified` + `sources`) to all 5 mise-tooling references, compatible with `check_freshness.py`
- Created terminal stack profile (`.terminal-guru-profile.local.md`) for agent self-improvement

## Metrics
- **Skill (mise-tooling):** 91/100 (up from 90)
- **Agent (terminal-guru):** 90/100 (maintained)
- **Freshness:** 100/100 (all 5 references tracked)
- **Plugin:** 5.1.0 → 5.2.0

## Test plan
- [x] `evaluate_skill.py` on mise-tooling: 91/100
- [x] `evaluate_agent.py` on terminal-guru: 90/100
- [x] `check_freshness.py` on mise-tooling: 100/100, all refs have frontmatter
- [x] SKILL.md stays under 150 lines (104 lines)
- [x] Marketplace synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)