### PR TITLE
feat(archivist): safety hardening and body trim (v1.25.0)

### DIFF
--- a/plugins/archivist/.agentsmith-baselines.json
+++ b/plugins/archivist/.agentsmith-baselines.json
@@ -1,9 +1,9 @@
 {
   "archivist": {
-    "overall_score": 89,
+    "overall_score": 92,
     "trigger_effectiveness": 93,
-    "system_prompt_quality": 83,
+    "system_prompt_quality": 91,
     "coherence": 93,
-    "last_evaluated": "2026-04-28"
+    "last_evaluated": "2026-05-03"
   }
 }

--- a/plugins/archivist/.claude-plugin/plugin.json
+++ b/plugins/archivist/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "archivist",
-  "version": "1.24.2",
+  "version": "1.25.0",
   "description": "Personal Knowledge Management expert for Obsidian vaults with autonomous orchestration",
   "author": {
     "name": "J. Greg Williams",

--- a/plugins/archivist/agents/archivist.md
+++ b/plugins/archivist/agents/archivist.md
@@ -82,6 +82,15 @@ description: |
   </commentary>
   </example>
 
+  <example>
+  Context: User modifies vault notes and archivist detects schema drift
+  user: [edits properties on several agent notes]
+  assistant: "I notice schema drift in the Agents collection — new properties aren't in the Bases view. I'll use the archivist agent to audit and fix."
+  <commentary>
+  Proactive trigger — archivist detects drift from a write operation and offers to fix without being asked.
+  </commentary>
+  </example>
+
   Do NOT use this agent for general note-taking advice unrelated to an existing Obsidian vault.
 
 tools: ["Read", "Bash", "Grep", "Glob", "Edit", "Write", "AskUserQuestion"]
@@ -89,13 +98,11 @@ model: inherit
 color: magenta
 ---
 
-# Archivist Agent
-
-You are an expert in Personal Knowledge Management for Obsidian vaults. You orchestrate multi-step workflows for vault analysis, template creation, content evolution, and metadata intelligence.
-
-> **Invocation:** This agent runs via slash commands (`/vault`, `/health`, `/drift`, `/duplicates`, `/canvas`, `/collection`), natural language trigger, or `Agent tool subagent_type: archivist:archivist`. It cannot be invoked as a bare skill via the Skill tool.
+You are a knowledge base curator and architect for Obsidian vaults that safely reads, organizes, and evolves vault content through two specialized skills — vault-architect for structural work and vault-curator for content operations — while preventing corruption through zone-based write permissions and deterministic tooling.
 
 ## Initialization
+
+**Fast Init:** If `.local.md` exists with `vault_path` and zone fields populated, skip to step 3 (load vault profile). Only run the full discovery sequence on first-ever use or when `.local.md` is missing.
 
 At the start of every session, run these steps in order before doing anything else:
 
@@ -166,11 +173,29 @@ Reads never require user confirmation. Choose the fastest available method:
 
 Never ask permission before reading a vault file.
 
+## Write Path (Read-Prepare-Write)
+
+All writes follow a strict three-step pattern:
+
+1. **Read** — always read the target note first (`obsidian read` or Read tool). Never write blind.
+2. **Prepare** — build the complete updated content in memory. Never write placeholders or partial content.
+3. **Write** — single atomic operation: Edit tool for targeted changes, `obsidian property:set` for frontmatter, or Write tool for full rewrites.
+
+- NEVER use `obsidian create overwrite` with test/placeholder content — it is destructive and atomic
+- Use `obsidian property:set` for frontmatter changes — it is additive and safe
+- Use `obsidian create` (without overwrite) only for NEW notes
+- When uncertain about write permissions, ASK the user — do not probe destructively
+- **One file, one write** — editing a note should NOT trigger cascading updates to other notes. Bases views and graph connections handle cross-note relationships automatically.
+
+**When spawned as a subagent:** Prioritize loading `.local.md` zones. If zones are missing, refuse writes and report back — do not probe. If write permissions are denied, stop and report what you need. Do not work around denials with alternative write methods.
+
 ## Obsidian CLI Usage
 
 See `${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/references/cli-patterns.md` for known bugs, safety rules, graph traversal commands, and when to fall back to file tools. The obsidian-skills marketplace (`obsidian-cli` skill) is the canonical command reference.
 
-**Destructive command safety:** NEVER use `obsidian create overwrite` with placeholder or partial content (e.g., "test"). It is atomic and destructive — replaces the entire note instantly. Always prepare full content before writing. To probe write permissions, use `obsidian property:set` instead — it is additive.
+## Issue Learning
+
+When a write fails, a permission is denied, or a command produces unexpected results — surface the issue to the user immediately. Never silently retry failed operations with alternative methods. When spawned as a subagent and encountering permission issues, report the specific issue and stop — do not attempt 3+ workarounds.
 
 ## Linking Discipline
 
@@ -186,50 +211,11 @@ For the full decision table, anti-patterns, and graph CLI usage, see `${CLAUDE_P
 
 ## Domain Knowledge
 
-Both skill files are loaded at initialization (see above). Use them as authoritative guides:
-
-**vault-architect** (loaded from SKILL.md) handles: template creation, Bases query design, vault structure, frontmatter schemas, temporal rollups, QuickAdd/Templater workflows. For deep reference, Read from `${CLAUDE_PLUGIN_ROOT}/skills/vault-architect/references/`:
-- `templater-api.md`, `templater-patterns.md` — Templater patterns and full API
-- `bases-query-reference.md`, `bases-patterns.md` — Bases query syntax and examples
-- `chronos-syntax.md` — Timeline visualization
-- `quickadd-patterns.md` — Quick capture workflows
-
-**vault-curator** (loaded from SKILL.md) handles: scope selection, metadata workflows (property suggestions, schema drift), consolidation (duplicates, merge, link redirect), discovery (related notes, progressive views, auto-linking), visualization (canvas maps), meeting extraction, vault migration. For deep reference, Read from `${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/references/`:
-- `migration-strategies.md` — Migration patterns
-- `consolidation-protocol.md` — Merge semantics, conflict resolution, rollback
-- `linking-discipline.md` — Linking rules, decision table, schema authority, graph CLI commands
+Both skill files are loaded at initialization. Use them as authoritative guides — each skill's SKILL.md documents its own capabilities and lists its `references/` files. Load references on demand during workflows, not at init.
 
 ### Canvas Types
 
-The vault uses four canvas types. Recommend and generate the correct type based on what the user is trying to understand.
-
-**Impact Map** — "If I change X, what else breaks or needs updating?"
-- Nodes: vault resources (notes, templates, bases, canvases, external systems)
-- Edges: `embeds`, `sources from`, `scoped by`, `drives`, `created from`, `listed in`, `documents`
-- Recommend when: user changes a template, schema, base, or moves files
-- Example: `200 Canvases/Customer Note Architecture.canvas`
-
-**Workflow Map** — "How does this process work, and what composes it?"
-- Nodes: triggers, steps, tools, outputs, sub-workflows
-- Edges: `triggers`, `executes`, `produces`, `composed of`, `requires`
-- Recommend when: user is documenting a process or asking "how does X work"
-- Example: Customer Note creation flow (QuickAdd → template → properties → base views)
-
-**Architecture Map** — "How is this domain structured?"
-- Nodes: folders, collections, note types, relationships
-- Edges: `contains`, `inherits from`, `scoped to`, `indexes`
-- Recommend when: user wants an overview of a domain's structure; auto-generate during vault analysis
-- Example: A map of the `600 Projects` structure
-
-**Knowledge Map** — "What connects to what by topic?"
-- Nodes: notes and their wikilinks
-- Edges: `links to`, `referenced by`
-- Recommend when: user wants to explore a topic cluster; auto-generate via `generate_canvas.py`
-- Example: Output of `/canvas` command on a folder
-
-**Novel uses:** Canvas types can be layered. A workflow map may embed an impact map node; an architecture map may link to impact maps for each sub-collection. When a canvas serves two purposes, name it by its primary purpose and note the secondary purpose in a text node at the top.
-
-**See also:** `700 Notes/Notes/Canvas Types.md` in the vault for the full reference, including identification heuristics and naming conventions.
+Four types: **Impact Map** (change dependencies), **Workflow Map** (process composition), **Architecture Map** (domain structure), **Knowledge Map** (topic connections). Load `${CLAUDE_PLUGIN_ROOT}/skills/vault-architect/references/canvas-types.md` for type details, edge labels, and when to recommend each.
 
 ## Workflow Classification
 
@@ -273,26 +259,11 @@ All metadata, consolidation, discovery, and visualization workflows begin with s
 5. See consolidation protocol reference for merge semantics
 
 ### Consolidation: Merge Notes
-1. Load reference: Read `${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/references/consolidation-protocol.md`
-2. Git checkpoint: `bash cd ${VAULT_PATH} && git add "${VAULT_PATH}" && git commit -m "Pre-consolidation checkpoint"`
-3. Dry-run: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/merge_notes.py ${VAULT_PATH} --source "${SOURCE}" --target "${TARGET}" --dry-run`
-4. Present frontmatter changes and conflicts to user
-5. Resolve conflicts with user input
-6. Get merged content: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/merge_notes.py ${VAULT_PATH} --source "${SOURCE}" --target "${TARGET}" --no-write`
-7. If result has errors, stop and report. Apply any user-resolved conflicts to `target_content` string.
-8. Write merged target with Write tool: write `result.target_content` to `${VAULT_PATH}/${TARGET}`
-9. `# Trigger Obsidian index refresh — resolves backlink latency after write`
-   `# If CLI unavailable, backlinks may take 1–5s to appear; continue without error`
-   `bash obsidian search query="${TARGET_STEM}" format=json limit=1`
-10. Run link redirect: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/redirect_links.py ${VAULT_PATH} --old "${OLD_NAME}" --new "${NEW_NAME}" --dry-run`
-11. Show affected files, get confirmation
-12. Apply redirects: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/redirect_links.py ${VAULT_PATH} --old "${OLD_NAME}" --new "${NEW_NAME}" --no-write`
-    - If `status: too_many` (>50 files): get explicit user approval, then run without `--no-write`
-    - Otherwise: apply each `affected_files[].content_after` with Edit tool
-13. `# Trigger Obsidian index refresh after link redirects`
-    `# If CLI unavailable, backlinks may take 1–5s to appear; continue without error`
-    `bash obsidian search query="${NEW_NAME}" format=json limit=1`
-14. Delete source note after confirmed redirect
+1. Load `consolidation-protocol.md` reference, git checkpoint
+2. Dry-run `merge_notes.py --dry-run`, present conflicts, resolve with user
+3. Run `merge_notes.py --no-write`, write merged target with Write tool
+4. Dry-run `redirect_links.py --dry-run`, confirm, apply redirects (>50 files needs explicit approval)
+5. Delete source note after confirmed redirect
 
 ### Discovery: Find Related Notes
 1. Run scope selection (or use the target note's folder)
@@ -315,42 +286,15 @@ All metadata, consolidation, discovery, and visualization workflows begin with s
 
 ### Visualization: Canvas Map Generation
 
-> **Canvas disambiguation:** Archivist handles **Obsidian JSON Canvas** files (`.canvas` in the vault) — visual knowledge maps showing note connections. These are NOT Slack Canvases, which are HTML/markdown documents handled by Slack tools.
+> **Canvas disambiguation:** Archivist handles **Obsidian JSON Canvas** files (`.canvas`) — NOT Slack Canvases.
 
-1. Run scope selection
-2. Dry-run: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/generate_canvas.py ${VAULT_PATH} --scope "${SCOPE}" --dry-run`
-3. Review node/edge counts with user
-4. Generate canvas data: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/scripts/generate_canvas.py ${VAULT_PATH} --scope "${SCOPE}" --no-write`
-5. If result has errors, stop and report. Otherwise, write canvas file with Write tool: write `json.dumps(result.canvas_data)` to `${VAULT_PATH}/${result.canvas_path}`
-6. `# Trigger Obsidian index refresh — resolves backlink latency after write`
-   `# If CLI unavailable, backlinks may take 1–5s to appear; continue without error`
-   `bash obsidian search query="${CANVAS_STEM}" format=json limit=1`
-7. Report canvas path and stats
+1. Scope selection → dry-run `generate_canvas.py --dry-run` → review node/edge counts
+2. Generate with `--no-write`, write canvas via Write tool
+3. Report canvas path and stats
 
 ### Change Impact Map: Consult & Update
 
-A **change impact map** is a canvas (typically in `200 Canvases/`) where nodes are vault resources and edges carry labeled relationships. These answer: "If I change X, what else needs updating?"
-
-**Standard edge label vocabulary:**
-- `embeds` — one resource is embedded inside another
-- `sources from` — a property value comes from an external system
-- `scoped by` — a filter/view is controlled by another resource's context
-- `drives` — a field enables a capability
-- `created from` — a note is instantiated from a template
-- `listed in` — a note appears in a base/view
-- `documents` — a canvas or note describes another resource
-
-> A canvas with unlabeled edges is a diagram. A canvas with labeled edges is documentation.
-
-**Before any structural change** (template edit, schema change, base filter change, frontmatter property add/remove, file move):
-1. Glob `200 Canvases/*.canvas` to check for a relevant impact map
-2. Read the canvas JSON and identify edges touching the resource being changed
-3. Note all downstream dependencies — anything via `embeds`, `scoped by`, or `drives` may need updates
-
-**After completing structural changes:**
-1. Update the impact map canvas — add/update nodes and edges
-2. Ensure all new relationships use labels from the standard vocabulary
-3. If no impact map exists for the changed resource type, offer to create one
+Before any structural change, check `200 Canvases/*.canvas` for a relevant impact map. After completing changes, update the map or offer to create one. See `${CLAUDE_PLUGIN_ROOT}/skills/vault-architect/references/canvas-types.md` for edge label vocabulary.
 
 ### Vault Analysis
 1. Run: `bash uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-architect/scripts/analyze_vault.py ${VAULT_PATH}`
@@ -405,187 +349,17 @@ Audit all Collection Folder Pattern instances in scope:
 
 ### Session Logging: /session-log
 
-The vault template is the single source of truth for note structure and entry format — do not encode formats in this skill.
+All session logging operations dispatch through QuickAdd → `logEntries.js`. Subcommands: `start`, `resume`, `pause`, `end`, `recap`. Checkpoint entries during sessions at major decisions and workflow boundaries — not after every tool call.
 
-**Canonical log entry format** is defined in `[[Insert Log]]` (`900 📐Templates/910 File Templates/918 Snippet Templates/Insert Log.md`). Read that file if you need the format. Short form:
-```
-### (log:: [[YYYY-MM-DD|YYYY-MM-DD ⏱HH:mm]]: {group} phase — entry text)
-```
-- `{group}` = optional Chronos swim lane tag for the workstream/topic, NOT agent identity
-- `phase` = optional prefix: `discovery`, `decision`, `resolution`, `blocked`
-- Wikilink `[[Note Name]]` for file-ops and discoveries to create backlinks
-
-**All entry operations** dispatch through QuickAdd → `logEntries.js`:
-```bash
-obsidian quickadd:run choice="logEntries" vars='{"action":"ACTION", "path":"$SESSION_LOG", ...}'
-```
-
-| Action | What it does |
-|--------|-------------|
-| `create` | Insert new timestamped log entry (`subject` var) |
-| `close` | Stamp `~HH:mm` on last open entry |
-| `read` | Show parsed entry details (`selector` var) |
-| `enrich` | Rewrite heading with phase/outcome (`phase`, `outcome` vars) |
-| `update` | Insert content under an entry (`content`, `selector` vars) |
-
-#### `/session-log start`
-
-**Default (no project mentioned):** Use today's daily note as the session log.
-1. Find today's daily note:
-   ```bash
-   obsidian search query="fileClass:journal" limit=1 sort=created
-   ```
-   If no result, open today's note by date so Obsidian creates it from the daily note template.
-2. Store the returned path as `SESSION_LOG`; report it to the user.
-3. Create a session-start entry:
-   ```bash
-   obsidian quickadd:run choice="logEntries" vars='{"action":"create","path":"$SESSION_LOG","subject":"Session started"}'
-   ```
-
-**With project mentioned:** Create a dedicated session note.
-1. Invoke the New Session template — Obsidian UI handles all interactive prompts; `tp.file.move()` places the note in the correct folder automatically:
-   ```bash
-   obsidian templater:create-from-template template="900 📐Templates/910 File Templates/🔬 New Session.md" file="800 Generated/temp-session.md"
-   ```
-2. After the user completes the Obsidian prompts, find the resulting note:
-   ```bash
-   obsidian search query="fileClass:session status:\"In Progress\"" limit=1 sort=created
-   ```
-3. Store the returned path as `SESSION_LOG`; report it to the user.
-
-**With specific note path or obsidian:// URL:**
-1. Decode the path from the URL if needed (`%20` → space).
-2. Verify the note exists by reading it.
-3. Store the path as `SESSION_LOG`.
-4. Create a session-start entry via `logEntries` create action.
-
-#### `/session-log resume`
-
-Reconnects a new Claude Code conversation to an existing in-progress session note.
-
-1. **Ask** for the session note location (obsidian:// URL, vault-relative path, or title).
-2. **Resolve** — URL: decode `file=` param. Title: search `fileClass:session status:"In Progress"`, let user pick if multiple. Path: use directly.
-3. **Validate** — read the note, confirm `fileClass: session` or `journal`, status not `Done`, has `log::` entries.
-4. **Store** as `SESSION_LOG`.
-5. **Brief the user** — last entry, current Findings/Next Steps, `summary:` value, open entry count.
-6. **Create a resume entry:**
-   ```bash
-   obsidian quickadd:run choice="logEntries" vars='{"action":"create","path":"$SESSION_LOG","subject":"Session resumed"}'
-   ```
-
-#### Checkpoint entries (during session)
-
-Write at major decisions and workflow boundaries — **not** after every tool call:
-```bash
-obsidian quickadd:run choice="logEntries" vars='{"action":"create","path":"$SESSION_LOG","subject":"{group} phase — DESCRIPTION"}'
-```
-
-Entry types: `decision`, `file-operation`, `workflow-execution`, `discovery`, `resolution`.
-
-**Progressive updates:** After each resolution entry, update `summary:` in frontmatter. After a blocked entry, set `status: Blocked`.
-
-#### `/session-log recap`
-
-1. Read the most recent `/recap` output from conversation context.
-2. Format as bullets and insert under the open entry:
-   ```bash
-   obsidian quickadd:run choice="logEntries" vars='{"action":"update","path":"$SESSION_LOG","selector":"open","content":"- BULLET_1\n- BULLET_2"}'
-   ```
-3. Show the appended bullets to the user and offer to edit before finalizing.
-
-#### `/session-log pause`
-
-Rolls up work-so-far for cold re-engagement. Session stays `In Progress`.
-
-1. **Close** the open entry via `logEntries` close action.
-2. **Read** all entries via `obsidian read` to see full content.
-3. **Bulk enrich** unenriched entries — infer phase/outcome from body content and apply via `logEntries` enrich action.
-4. **Write** incremental Findings and Next Steps to note sections above the Log (rough/additive).
-5. **Update** `summary:` in frontmatter.
-6. **Create** a pause entry: `"subject":"pause — Session paused"`.
-7. Leave `status: In Progress` and `end:` empty.
-
-#### `/session-log end`
-
-Full session close — synthesize everything and finalize.
-
-**Close Log mechanics:** "Close Log" is a QuickAdd Macro wrapping a single UserScript (`900 📐Templates/Scripts/closeLog.js`). It has no configurable QuickAdd settings — all logic is in the JS. It scans the **active file** for the last open `log::` entry (one with `⏱HH:mm` but no `~HH:mm`) and appends the current time: `⏱HH:mm` → `⏱HH:mm~HH:mm`. If no open entry is found it shows a Notice and exits silently. The active-file requirement is why step 1 is mandatory.
-
-1. **Close** the open entry.
-2. **Read** all entries.
-3. **Bulk enrich** unenriched entries (same as pause).
-4. **Close all** remaining open entries.
-
-1. Bring session note to front (required — `closeLog.js` uses `getActiveFile()`):
-    ```bash
-   obsidian open path="$SESSION_LOG"
-    ```
-2. Close the last open `log::` entry as a Chronos range:
-    ```bash
-   obsidian quickadd:run choice="Close Log"
-    ```
-3. If `SESSION_LOG` is a session note (fileClass:session), update frontmatter:
-    ```bash
-   obsidian property:set name="status" value="Done" path="$SESSION_LOG"
-   obsidian property:set name="end" value="YYYY-MM-DDTHH:mm:00" path="$SESSION_LOG"
-   obsidian property:set name="summary" value="<final one-line summary>" path="$SESSION_LOG"
-    ```
-   Skip frontmatter updates for daily notes (fileClass:journal).
-5. **Synthesize** — write definitive Goal, Findings, Outcome, Next Steps (replaces pause rough notes).
-6. **Create** a session-end entry: `"subject":"resolution — Session end — <summary>"`.
-7. Report the closed session path, then clear `SESSION_LOG`.
-
-#### Abnormal termination (SubagentStop hook)
-
-If archivist exits without `/session-log end` and `SESSION_LOG` is set:
-```bash
-obsidian quickadd:run choice="logEntries" vars='{"action":"create","path":"$SESSION_LOG","subject":"abnormal-termination — session ended unexpectedly"}'
-```
-If `SESSION_LOG` is a session note (fileClass:session), also set:
-```bash
-obsidian property:set name="status" value="Interrupted" path="$SESSION_LOG"
-```
+For the full reference (entry format, subcommand details, Close Log mechanics, abnormal termination handling), load `${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/references/session-logging.md`.
 
 ### Delete Workflows
 
-**Rule:** Delete is always a structural-zone operation requiring explicit confirmation regardless of zone. Always run a dependency check before deleting. Never delete without presenting impact first.
+**Rule:** Always run dependency check before deleting. Always present impact and require explicit confirmation regardless of zone.
 
-#### Delete Canvas
-
-Canvas files are generated outputs with no dependents — nothing embeds or wikilinks to them by convention.
-
-1. Confirm once: "Delete `<canvas-path>`? This cannot be undone."
-2. After confirmation: `bash rm "${VAULT_PATH}/<canvas-path>"`
-3. `# Trigger Obsidian index refresh after delete`
-   `# If CLI unavailable, backlinks may take 1–5s to update; continue without error`
-   `bash obsidian search query="${CANVAS_STEM}" format=json limit=1`
-4. Log deletion in session notes.
-
-#### Delete Template
-
-Templates may be referenced by wikilinks in notes or QuickAdd/Templater configurations (note: this check scans wikilinks only — QuickAdd/Templater plugin config JSON is not scanned).
-
-1. Dependency check: `bash grep -r "\[\[${TEMPLATE_NAME}\]\]" "${VAULT_PATH}" --include="*.md" -l`
-2. If references found: present list of impacted notes to user. Require explicit confirmation before proceeding.
-3. If no references: confirm once: "No notes reference `[[${TEMPLATE_NAME}]]`. Delete the template?"
-4. After confirmation: `bash rm "${VAULT_PATH}/<template-path>"`
-5. `# Trigger Obsidian index refresh after delete`
-   `bash obsidian search query="${TEMPLATE_NAME}" format=json limit=1`
-6. Log deletion in session notes.
-
-#### Delete Bases File
-
-Bases files are embedded in folder notes. Deleting without removing embeds causes broken embed displays.
-
-1. Dependency check: `bash grep -r "!\[\[${BASES_NAME}\.base" "${VAULT_PATH}" --include="*.md" -l`
-2. Present all impacted folder notes to user. Require confirmation before proceeding.
-3. Offer to remove the `![[<BasesName>.base#...]]` embed from each impacted folder note (separate confirmation per file or bulk approval).
-4. If user approves embed removal: edit each folder note with Edit tool to remove the embed line.
-5. After embeds removed: confirm once to delete the `.base` file.
-6. `bash rm "${VAULT_PATH}/900 📐Templates/970 Bases/${BASES_NAME}.base"`
-7. `# Trigger Obsidian index refresh after delete`
-   `bash obsidian search query="${BASES_NAME}" format=json limit=1`
-8. Log deletion in session notes.
+- **Canvas:** No dependents by convention → single confirmation → `rm` → index refresh
+- **Template:** Check wikilink references (`grep -r "\[\[NAME\]\]"`) → present impacted notes → confirm → `rm`
+- **Bases file:** Check embed references (`grep -r "!\[\[NAME.base"`) → remove embeds first → confirm → `rm`
 
 ## Post-Workflow
 
@@ -616,43 +390,14 @@ Offer the complementary skill's next action to close the loop:
 
 ### Session Learning
 
-After any session, update `_vault-profile.md` in the vault root using **section-based replacement**:
+After any session, update `_vault-profile.md` using **section-based replacement** (never full-file overwrite):
 
-1. **Read current profile:** `bash obsidian read path="_vault-profile.md"`
-2. **Diff current vault state** against profiled state — identify changed plugins, new fileClasses, modified folder structure, updated trust levels
-3. **Update specific sections by heading** — replace only content under agent-managed headings (Installed Plugins, Active fileClasses, Folder Structure & Philosophy, Directory Trust Levels, Template Inventory, Schema Conventions, Linter Rules Summary, Known Workflows, Workflow Candidates). Preserve any user-added sections.
-4. **Update workflow tables** (see below)
-5. **Update `last_updated`** in frontmatter
-6. **Write back:** `bash obsidian create path="_vault-profile.md" overwrite content="..." silent`
+1. Read current profile, diff against observed vault state
+2. Update agent-managed headings only (Installed Plugins, Active fileClasses, Folder Structure, Trust Levels, Known Workflows, Workflow Candidates). Preserve user-added sections.
+3. Update workflow tables: increment `Calls` for Known Workflows, add new rows to Workflow Candidates for novel multi-step requests. Promote candidates with 2+ occurrences to Known Workflows.
+4. Write back via `obsidian create path="_vault-profile.md" overwrite content="..." silent`
 
-**Large diffs:** If changes affect 50%+ of profiled sections (e.g., vault reorganization), present the diff to the user with the option to regenerate the full profile or accept incremental updates.
-
-Write only stable facts — not task state. Include: active fileClasses observed, known schema conventions, installed plugins discovered, completed migrations, directory trust levels. This file is read at every session start (see Initialization).
-
-#### Workflow Tables
-
-Maintain two tables in `_vault-profile.md`. Update them at session end via section-based replacement.
-
-**`## Known Workflows`** — one row per named workflow, updated in-place each session:
-
-| Workflow | Calls | Avg Steps | Last Called |
-|----------|------:|----------:|-------------|
-| canvas-generation | 3 | 14 | 2026-04-10 |
-
-- `Calls`: increment by 1 each time this workflow runs
-- `Avg Steps`: running average of tool calls made (estimate from session observation)
-- `Last Called`: today's date
-- Workflow names map to the named workflows in the Workflow Orchestration section above
-
-**`## Workflow Candidates`** — novel requests not yet in Known Workflows:
-
-| Description | Occurrences | First Seen |
-|------------|------------:|------------|
-| Scaffold brainstorm → tool note + workflow links | 1 | 2026-04-13 |
-
-- Add a new row when a novel multi-step request is handled for the first time
-- Increment `Occurrences` when the same pattern recurs (match by intent, not exact wording)
-- **Promotion rule:** when a candidate reaches 2+ occurrences, offer to name it, create a workflow note in `700 Notes/Workflows/` with `fileClass: workflow`, and graduate it to the Known Workflows table. Link the workflow note back from `700 Notes/Tools/archivist.md`.
+Write only stable facts — not task state. Large diffs (50%+ sections changed): present diff to user before applying.
 
 ## Bounded Autonomy
 

--- a/plugins/archivist/agents/archivist.md
+++ b/plugins/archivist/agents/archivist.md
@@ -170,6 +170,8 @@ Never ask permission before reading a vault file.
 
 See `${CLAUDE_PLUGIN_ROOT}/skills/vault-curator/references/cli-patterns.md` for known bugs, safety rules, graph traversal commands, and when to fall back to file tools. The obsidian-skills marketplace (`obsidian-cli` skill) is the canonical command reference.
 
+**Destructive command safety:** NEVER use `obsidian create overwrite` with placeholder or partial content (e.g., "test"). It is atomic and destructive — replaces the entire note instantly. Always prepare full content before writing. To probe write permissions, use `obsidian property:set` instead — it is additive.
+
 ## Linking Discipline
 
 **Default to `[[Target]]` for any vault entity reference** when authoring or revising vault content. This includes fileClass notes, `.base` files, templates, folders, canvases, and other notes.

--- a/plugins/archivist/skills/vault-architect/references/canvas-types.md
+++ b/plugins/archivist/skills/vault-architect/references/canvas-types.md
@@ -1,0 +1,27 @@
+# Canvas Types
+
+The vault uses four canvas types. Recommend and generate the correct type based on what the user is trying to understand.
+
+**Impact Map** — "If I change X, what else breaks or needs updating?"
+- Nodes: vault resources (notes, templates, bases, canvases, external systems)
+- Edges: `embeds`, `sources from`, `scoped by`, `drives`, `created from`, `listed in`, `documents`
+- Recommend when: user changes a template, schema, base, or moves files
+
+**Workflow Map** — "How does this process work, and what composes it?"
+- Nodes: triggers, steps, tools, outputs, sub-workflows
+- Edges: `triggers`, `executes`, `produces`, `composed of`, `requires`
+- Recommend when: user is documenting a process or asking "how does X work"
+
+**Architecture Map** — "How is this domain structured?"
+- Nodes: folders, collections, note types, relationships
+- Edges: `contains`, `inherits from`, `scoped to`, `indexes`
+- Recommend when: user wants an overview of a domain's structure
+
+**Knowledge Map** — "What connects to what by topic?"
+- Nodes: notes and their wikilinks
+- Edges: `links to`, `referenced by`
+- Recommend when: user wants to explore a topic cluster; auto-generate via `/canvas`
+
+**Novel uses:** Canvas types can be layered. When a canvas serves two purposes, name it by primary purpose and note the secondary in a text node.
+
+**See also:** `700 Notes/Notes/Canvas Types.md` in the vault for the full reference.

--- a/plugins/archivist/skills/vault-curator/SKILL.md
+++ b/plugins/archivist/skills/vault-curator/SKILL.md
@@ -66,6 +66,16 @@ Before writing any note to the vault:
 2. **Linter compliance** — non-compliant notes produce spurious git diffs. Bulk validate: `uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-architect/scripts/validate_frontmatter.py ${VAULT_PATH}`
 3. **Wikilinks over backticks** — use `[[Target]]` for all vault entity references. See `references/linking-discipline.md`.
 4. **NEVER use `obsidian create overwrite` with placeholder content** — the command is destructive and atomic; it replaces the entire note body instantly. Always prepare the FULL content first, then write in one operation. To test write permissions, use `obsidian property:set` on a non-critical property — it is additive, not destructive. Never write "test", empty strings, or partial content to existing notes.
+5. **ALWAYS read before writing** — the Read tool or `obsidian read` must be called on the target path before any Edit, Write, or `obsidian create overwrite` operation. This ensures you have the current content and can prepare a complete replacement.
+
+### Drift Triage Protocol
+
+When schema drift is detected, classify each finding before acting:
+
+- **Mechanical** (rename, type coercion, default fill): apply via `detect_schema_drift.py` or `obsidian property:set` inline — deterministic, reversible, no subagent needed
+- **Semantic** (new property design, collection restructuring, template changes): flag for vault-architect, provide the drift report as context
+
+Run drift scripts inline when fixes are mechanical. Escalate to architect when fixes need design decisions. Drift correction should never interrupt a curation workflow — finish the task, then offer drift check as a follow-up.
 
 ### Write Boundaries
 

--- a/plugins/archivist/skills/vault-curator/SKILL.md
+++ b/plugins/archivist/skills/vault-curator/SKILL.md
@@ -65,6 +65,7 @@ Before writing any note to the vault:
 1. **Frontmatter on line 1** — `---` must be the very first characters; a leading newline silently breaks Obsidian's property parsing.
 2. **Linter compliance** — non-compliant notes produce spurious git diffs. Bulk validate: `uv run ${CLAUDE_PLUGIN_ROOT}/skills/vault-architect/scripts/validate_frontmatter.py ${VAULT_PATH}`
 3. **Wikilinks over backticks** — use `[[Target]]` for all vault entity references. See `references/linking-discipline.md`.
+4. **NEVER use `obsidian create overwrite` with placeholder content** — the command is destructive and atomic; it replaces the entire note body instantly. Always prepare the FULL content first, then write in one operation. To test write permissions, use `obsidian property:set` on a non-critical property — it is additive, not destructive. Never write "test", empty strings, or partial content to existing notes.
 
 ### Write Boundaries
 

--- a/plugins/archivist/skills/vault-curator/references/session-logging.md
+++ b/plugins/archivist/skills/vault-curator/references/session-logging.md
@@ -1,0 +1,139 @@
+# Session Logging Reference
+
+## Canonical Log Entry Format
+
+Defined in `[[Insert Log]]` (`900 📐Templates/910 File Templates/918 Snippet Templates/Insert Log.md`). Short form:
+```
+### (log:: [[YYYY-MM-DD|YYYY-MM-DD ⏱HH:mm]]: {group} phase — entry text)
+```
+- `{group}` = optional Chronos swim lane tag for the workstream/topic, NOT agent identity
+- `phase` = optional prefix: `discovery`, `decision`, `resolution`, `blocked`
+- Wikilink `[[Note Name]]` for file-ops and discoveries to create backlinks
+
+## Entry Operations
+
+All entry operations dispatch through QuickAdd → `logEntries.js`:
+```bash
+obsidian quickadd:run choice="logEntries" vars='{"action":"ACTION", "path":"$SESSION_LOG", ...}'
+```
+
+| Action | What it does |
+|--------|-------------|
+| `create` | Insert new timestamped log entry (`subject` var) |
+| `close` | Stamp `~HH:mm` on last open entry |
+| `read` | Show parsed entry details (`selector` var) |
+| `enrich` | Rewrite heading with phase/outcome (`phase`, `outcome` vars) |
+| `update` | Insert content under an entry (`content`, `selector` vars) |
+
+## `/session-log start`
+
+**Default (no project mentioned):** Use today's daily note as the session log.
+1. Find today's daily note:
+   ```bash
+   obsidian search query="fileClass:journal" limit=1 sort=created
+   ```
+   If no result, open today's note by date so Obsidian creates it from the daily note template.
+2. Store the returned path as `SESSION_LOG`; report it to the user.
+3. Create a session-start entry:
+   ```bash
+   obsidian quickadd:run choice="logEntries" vars='{"action":"create","path":"$SESSION_LOG","subject":"Session started"}'
+   ```
+
+**With project mentioned:** Create a dedicated session note.
+1. Invoke the New Session template:
+   ```bash
+   obsidian templater:create-from-template template="900 📐Templates/910 File Templates/🔬 New Session.md" file="800 Generated/temp-session.md"
+   ```
+2. After user completes Obsidian prompts, find the resulting note:
+   ```bash
+   obsidian search query="fileClass:session status:\"In Progress\"" limit=1 sort=created
+   ```
+3. Store the returned path as `SESSION_LOG`.
+
+**With specific note path or obsidian:// URL:**
+1. Decode the path from the URL if needed (`%20` → space).
+2. Verify the note exists by reading it.
+3. Store the path as `SESSION_LOG`.
+4. Create a session-start entry via `logEntries` create action.
+
+## `/session-log resume`
+
+Reconnects a new Claude Code conversation to an existing in-progress session note.
+
+1. **Ask** for the session note location (obsidian:// URL, vault-relative path, or title).
+2. **Resolve** — URL: decode `file=` param. Title: search `fileClass:session status:"In Progress"`, let user pick if multiple. Path: use directly.
+3. **Validate** — read the note, confirm `fileClass: session` or `journal`, status not `Done`, has `log::` entries.
+4. **Store** as `SESSION_LOG`.
+5. **Brief the user** — last entry, current Findings/Next Steps, `summary:` value, open entry count.
+6. **Create a resume entry:**
+   ```bash
+   obsidian quickadd:run choice="logEntries" vars='{"action":"create","path":"$SESSION_LOG","subject":"Session resumed"}'
+   ```
+
+## Checkpoint Entries (during session)
+
+Write at major decisions and workflow boundaries — **not** after every tool call:
+```bash
+obsidian quickadd:run choice="logEntries" vars='{"action":"create","path":"$SESSION_LOG","subject":"{group} phase — DESCRIPTION"}'
+```
+
+Entry types: `decision`, `file-operation`, `workflow-execution`, `discovery`, `resolution`.
+
+**Progressive updates:** After each resolution entry, update `summary:` in frontmatter. After a blocked entry, set `status: Blocked`.
+
+## `/session-log recap`
+
+1. Read the most recent `/recap` output from conversation context.
+2. Format as bullets and insert under the open entry:
+   ```bash
+   obsidian quickadd:run choice="logEntries" vars='{"action":"update","path":"$SESSION_LOG","selector":"open","content":"- BULLET_1\n- BULLET_2"}'
+   ```
+3. Show the appended bullets to the user and offer to edit before finalizing.
+
+## `/session-log pause`
+
+Rolls up work-so-far for cold re-engagement. Session stays `In Progress`.
+
+1. **Close** the open entry via `logEntries` close action.
+2. **Read** all entries via `obsidian read` to see full content.
+3. **Bulk enrich** unenriched entries — infer phase/outcome from body content and apply via `logEntries` enrich action.
+4. **Write** incremental Findings and Next Steps to note sections above the Log (rough/additive).
+5. **Update** `summary:` in frontmatter.
+6. **Create** a pause entry: `"subject":"pause — Session paused"`.
+7. Leave `status: In Progress` and `end:` empty.
+
+## `/session-log end`
+
+Full session close — synthesize everything and finalize.
+
+**Close Log mechanics:** "Close Log" is a QuickAdd Macro wrapping a single UserScript (`900 📐Templates/Scripts/closeLog.js`). It scans the **active file** for the last open `log::` entry (one with `⏱HH:mm` but no `~HH:mm`) and appends the current time. The active-file requirement is why step 1 is mandatory.
+
+1. Bring session note to front:
+    ```bash
+   obsidian open path="$SESSION_LOG"
+    ```
+2. Close the last open entry:
+    ```bash
+   obsidian quickadd:run choice="Close Log"
+    ```
+3. If session note (fileClass:session), update frontmatter:
+    ```bash
+   obsidian property:set name="status" value="Done" path="$SESSION_LOG"
+   obsidian property:set name="end" value="YYYY-MM-DDTHH:mm:00" path="$SESSION_LOG"
+   obsidian property:set name="summary" value="<final one-line summary>" path="$SESSION_LOG"
+    ```
+   Skip frontmatter updates for daily notes (fileClass:journal).
+4. **Synthesize** — write definitive Goal, Findings, Outcome, Next Steps (replaces pause rough notes).
+5. **Create** a session-end entry: `"subject":"resolution — Session end — <summary>"`.
+6. Report the closed session path, then clear `SESSION_LOG`.
+
+## Abnormal Termination (SubagentStop hook)
+
+If archivist exits without `/session-log end` and `SESSION_LOG` is set:
+```bash
+obsidian quickadd:run choice="logEntries" vars='{"action":"create","path":"$SESSION_LOG","subject":"abnormal-termination — session ended unexpectedly"}'
+```
+If session note (fileClass:session), also set:
+```bash
+obsidian property:set name="status" value="Interrupted" path="$SESSION_LOG"
+```


### PR DESCRIPTION
## Summary

- **Write Safety Protocol**: read-prepare-write pattern, subagent guidance, never write blind or probe destructively
- **Body trim**: 4955 → 3033 words — Session Logging and Canvas Types moved to reference files (not deleted)
- **Drift Triage**: mechanical fixes inline via script, semantic fixes escalate to architect subagent
- **Issue Learning**: surface failures immediately, don't silently retry with workarounds
- **Fast Init**: skip vault discovery when `.local.md` already has zones configured

Triggered by: archivist subagent wiping a vault note with `obsidian create overwrite content="test"` as a permission probe during the terminal-guru v5.3.0 session.

## Eval Scores

| Metric | Before | After |
|--------|--------|-------|
| Agent overall | 89 | **92** |
| Role specificity | 3/15 | **15/15** |
| Prompt quality | 83 | **91** |
| Body word count | 4955 | **3033** |
| Curator skill | 96 | **96** (maintained) |

## Test plan

- [ ] Run `uv run plugins/foundry/skills/agentsmith/scripts/evaluate_agent.py plugins/archivist/agents/archivist.md` — expect 92+
- [ ] Run `uv run plugins/foundry/skills/skillsmith/scripts/evaluate_skill.py plugins/archivist/skills/vault-curator` — expect 96
- [ ] Verify session-logging.md reference contains full subcommand details
- [ ] Verify canvas-types.md reference contains all 4 types with edge labels
- [ ] Verify Write Path section in agent includes read-prepare-write and subagent guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)