### PR TITLE
feat(archivist): auto-discover write zones from vault profile (v1.28.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -58,7 +58,7 @@
       "name": "archivist",
       "description": "Personal Knowledge Management expert for Obsidian vaults with dual-skill architecture: vault-architect (create structures) and vault-curator (evolve content)",
       "category": "productivity",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "author": {
         "name": "J. Greg Williams",
         "email": "283704+totallyGreg@users.noreply.github.com"

--- a/plugins/archivist/.agentsmith-baselines.json
+++ b/plugins/archivist/.agentsmith-baselines.json
@@ -4,6 +4,6 @@
     "trigger_effectiveness": 93,
     "system_prompt_quality": 95,
     "coherence": 93,
-    "last_evaluated": "2026-06-06"
+    "last_evaluated": "2026-06-08"
   }
 }

--- a/plugins/archivist/.claude-plugin/plugin.json
+++ b/plugins/archivist/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "archivist",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Personal Knowledge Management expert for Obsidian vaults with autonomous orchestration",
   "author": {
     "name": "J. Greg Williams",

--- a/plugins/archivist/README.md
+++ b/plugins/archivist/README.md
@@ -81,6 +81,7 @@ Overall score: **71%** ([#160](https://github.com/totallyGreg/claude-mp/issues/1
 
 | Version | Date | Issue | Summary |
 |---------|------|-------|---------|
+| 1.28.0 | 2026-06-08 | - | Auto-discover write zones from vault profile when `.local.md` lacks them. Init step 3 now derives `architect_write_zones`/`curator_write_zones`/`designated_output_zones` from `_vault-profile.md` "Directory Trust Levels" table using mapping: `infrastructure` → architect, `personal/guarded`+`project-scoped` → curator, `automated/generated` → designated_output. Derived zones apply for the session; one-time AskUserQuestion offer to persist to `.local.md`. Policy-based refusals now prefix `Archivist policy:` to disambiguate from Claude Code tooling-layer denials (the "denied" wording was sending users down the wrong debugging path — see today's friction report). Empirical evidence: today's session spent ~90 min chasing a Claude Code permission bug that turned out to be the archivist's own bounded-autonomy refusing due to missing `.local.md`. Agent eval 93 (no change — substantive logic, not example/length metrics). |
 | 1.27.0 | 2026-06-06 | [#176](https://github.com/totallyGreg/claude-mp/issues/176) | Pass A (friction batch 2026-06-05). A1: Denial Handling — Mode 1/Mode 2 recovery guidance with `permissions.allow` schema + JSON example; Mode 2 labeled "observed empirically, not root-caused." A2: Subagent Input Volume Guard — token-count + file-path-count trigger (not category labels); soft-confirm path before refusal; defense-in-depth framing. A3: External-System Handoffs — new table in §Post-Workflow routing meeting-extraction action items to `attache:attache`. Agent eval 93 (no change). |
 | 1.26.0 | 2026-06-04 | [#160](https://github.com/totallyGreg/claude-mp/issues/160), [#129](https://github.com/totallyGreg/claude-mp/issues/129) | Friction fixes (2026-06-04 + 2026-05-28 reports) + Tier-1 wins from #160. Strict Denial Handling (stop on first denial across primitives, Read tool ≠ obsidian read ≠ Write's internal gate, pre-flight refusal when zones missing). Reference Formatting rule (wikilink intra-vault, file:// external, backticks code-only). Index refresh after Python writes. Init drift signal on primary fileClass. New `duplicate-detection-thresholds.md` policy reference. Closed #129 as superseded by current architecture. Agent eval 92→93 (Prompt 91→95). |
 | 1.25.0 | 2026-05-03 | - | Safety hardening: Write Path (read-prepare-write protocol), Issue Learning, Fast Init, anti-cascade principle, Drift Triage in curator (mechanical vs semantic). Body trim 4955→3033 words (session-logging + canvas-types moved to references). Agent eval 89→92 (Role:3→15, Prompt:83→91). |
@@ -93,16 +94,17 @@ Overall score: **71%** ([#160](https://github.com/totallyGreg/claude-mp/issues/1
 
 ### Current Metrics
 
-**Score: 94/100** (Good) — 2026-06-06
+**Score: 93/100** (Good) — 2026-06-08
 
 | Concs | Complx | Spec | Progr | Descr |
 |-------|--------|------|-------|-------|
-| 77 | 90 | 100 | 100 | 100 |
+| 76 | 90 | 100 | 100 | 100 |
 
 ### Version History
 
 | Version | Date | Issue | Summary | Concs | Complx | Spec | Progr | Descr | Score |
 |---------|------|-------|---------|-------|--------|------|-------|-------|-------|
+| 1.12.0 | 2026-06-08 | - | Align §Write Boundaries with auto-discovery: "No zones configured in `.local.md`" now references the agent's profile-derived zones (mapping doc) rather than refusing outright; refusals prefixed `Archivist policy:` to disambiguate from Claude Code tooling-layer denials. Score 94→93 (Concs 77→76 from added prose; substantive consistency with agent v1.28.0). | 76 | 90 | 100 | 100 | 100 | 93 |
 | 1.11.0 | 2026-06-06 | [#176](https://github.com/totallyGreg/claude-mp/issues/176) | Pass C (friction batch 2026-06-05). C1: notation hygiene added to Design Principles "Do:" — per-template pick, prefer Obsidian-native `- [ ]`/`- [x]`, extended markers require Tasks plugin verification, no proactive retrofit. §10 Vault System Documentation updated to include Notation Conventions entry. Also fixed SKILL.md version drift (was stuck at 1.9.0 while README was at 1.10.0). Score 94 (Concs 79→77 from added text; overall floor met). | 77 | 90 | 100 | 100 | 100 | 94 |
 | 1.10.0 | 2026-04-14 | [#160](https://github.com/totallyGreg/claude-mp/issues/160) | Add vault-analysis-checks.md (analyze_vault.py check reference) and frontmatter-schema-reference.md (validate_frontmatter.py fields, severity, violations); update SKILL.md to reference both | 79 | 90 | 100 | 100 | 100 | 93 |
 | 1.9.0 | 2026-04-11 | - | Add linking discipline to Design Principles: link aggressively, no backticked vault entities; schema authority: .base default view is canonical, fileClass mirrors it; pointer to linking-discipline.md | 79 | 90 | 100 | 100 | 100 | 93 |
@@ -123,16 +125,17 @@ Overall score: **71%** ([#160](https://github.com/totallyGreg/claude-mp/issues/1
 
 ### Current Metrics
 
-**Score: 96/100** (Excellent) — 2026-06-06
+**Score: 96/100** (Excellent) — 2026-06-08
 
 | Concs | Complx | Spec | Progr | Descr |
 |-------|--------|------|-------|-------|
-| 79 | 100 | 100 | 100 | 100 |
+| 78 | 100 | 100 | 100 | 100 |
 
 ### Version History
 
 | Version | Date | Issue | Summary | Concs | Complx | Spec | Progr | Descr | Score |
 |---------|------|-------|---------|-------|--------|------|-------|-------|-------|
+| 1.16.0 | 2026-06-08 | - | Align §Write Boundaries with agent's profile-derived zone discovery: "No zones configured in `.local.md`" no longer terminates — derived zones from `_vault-profile.md` apply if present. Refusal phrasing standardized to `Archivist policy:` prefix to disambiguate from Claude Code tooling-layer denials. Score 96 (Concs 79→78 from added refusal-phrasing rule; overall unchanged). | 78 | 100 | 100 | 100 | 100 | 96 |
 | 1.15.0 | 2026-06-06 | [#176](https://github.com/totallyGreg/claude-mp/issues/176) | Pass B (friction batch 2026-06-05). B1: fileClass validation gate (item 6) — re-read `_vault-profile.md` from disk per write (freshness), parse Active fileClasses (table→bullet→warn-and-skip), refuse+surface gap if value absent. B2: entity wikilink check (item 3a) — batch scan with stop-list, code-fence skip, ~20 cap, single consolidated end-of-scan prompt (no per-candidate blocking). B3: schema-change guard in §Write Boundaries — hard-stop on fileClass/folder-convention/template-schema creation, explicit vault-architect routing. Score 96 (Concs 80→79 from added prose, overall unchanged). | 79 | 100 | 100 | 100 | 100 | 96 |
 | 1.14.0 | 2026-06-04 | [#160](https://github.com/totallyGreg/claude-mp/issues/160) | Add `duplicate-detection-thresholds.md` reference (canvas, similarity, coverage thresholds with tuning guidance); link from Find Similar Notes and Canvas Map Generation sections | 80 | 100 | 100 | 100 | 100 | 96 |
 | 1.13.0 | 2026-05-03 | - | Add Write Quality Gate rule #5 (read before write), Drift Triage protocol (mechanical vs semantic), session-logging.md reference | 80 | 100 | 100 | 100 | 100 | 96 |

--- a/plugins/archivist/agents/archivist.md
+++ b/plugins/archivist/agents/archivist.md
@@ -153,6 +153,8 @@ At the start of every session, run these steps in order before doing anything el
    | `personal/guarded` or `project-scoped` | `curator_write_zones` |
    | `automated/generated` | `designated_output_zones` |
 
+   **Universal additions to derived `architect_write_zones`:** Always append `_vault-profile.md` after applying the mapping. The trust-levels table lists directories only, but `_vault-profile.md` is a single file at vault root that must be architect-tier protected — every full-rewrite must confirm, even though Session Learning's section-based updates bypass this via the dedicated rule (see Bounded Autonomy).
+
    Treat derived zones as if they were loaded from `.local.md` for the rest of the session. After derivation, **offer once** (via AskUserQuestion: Yes / No / Customize) to persist them to `.local.md` so future sessions skip the derivation step — do not block the current session on the answer.
    - **If it exists but is corrupted** (malformed YAML frontmatter, unparseable): regenerate from scratch using vault-architect's Vault Profiling workflow. Warn the user that the old profile was replaced.
 

--- a/plugins/archivist/agents/archivist.md
+++ b/plugins/archivist/agents/archivist.md
@@ -139,11 +139,21 @@ At the start of every session, run these steps in order before doing anything el
    - `architect_write_zones:` — comma-separated vault-relative paths where vault-architect may write
    - `curator_write_zones:` — comma-separated vault-relative paths where vault-curator may write
    - `designated_output_zones:` — free-write zone (no confirmation needed for creates)
-   - If zone fields are absent: when invoked top-level, all writes require explicit confirmation. **When spawned as a subagent, refuse writes up-front and report back** — do not probe permissions by attempting a write. After vault profiling (step 3), offer to write discovered zones back to `.local.md`.
+   - If zone fields are absent: defer to step 3. Zones may be derived from `_vault-profile.md`'s "Directory Trust Levels" section. Only fall back to confirm-all-writes (top-level) or refuse-with-`Archivist policy:`-message (subagent) if both sources lack zone information for the target path.
 
 3. **Load vault profile** — Check for `_vault-profile.md` in the vault root: `bash obsidian read path="_vault-profile.md"`.
    - **If it exists and parses correctly:** read it for accumulated context (installed plugins, active fileClasses, known conventions, past decisions, directory trust levels). Also load the `## Known Workflows` and `## Workflow Candidates` tables if present — these inform workflow classification (see below).
    - **If it is absent:** invoke vault-architect's **Vault Profiling** workflow to create it before proceeding. This is mandatory — do not skip profile creation on first run. After profiling completes, offer to write discovered zones to `.local.md` so future sessions skip confirmation prompts (use the Write tool to update `.local.md` with `architect_write_zones` and `curator_write_zones` populated from the vault structure).
+
+   **Zone derivation from profile (when `.local.md` lacks zones):** If step 2 found `.local.md` but it has no `architect_write_zones`/`curator_write_zones`/`designated_output_zones`, AND `_vault-profile.md` has a "Directory Trust Levels" table, derive zones from it using this mapping:
+
+   | Profile trust level | Maps to zone |
+   |---|---|
+   | `infrastructure` | `architect_write_zones` |
+   | `personal/guarded` or `project-scoped` | `curator_write_zones` |
+   | `automated/generated` | `designated_output_zones` |
+
+   Treat derived zones as if they were loaded from `.local.md` for the rest of the session. After derivation, **offer once** (via AskUserQuestion: Yes / No / Customize) to persist them to `.local.md` so future sessions skip the derivation step — do not block the current session on the answer.
    - **If it exists but is corrupted** (malformed YAML frontmatter, unparseable): regenerate from scratch using vault-architect's Vault Profiling workflow. Warn the user that the old profile was replaced.
 
 4. **Verify vault connection** — `bash obsidian vault` (returns vault name + file count). If it fails, fall back to file tools (Glob, Grep, Read) for all operations.
@@ -189,7 +199,7 @@ All writes follow a strict three-step pattern:
 - When uncertain about write permissions, ASK the user — do not probe destructively
 - **One file, one write** — editing a note should NOT trigger cascading updates to other notes. Bases views and graph connections handle cross-note relationships automatically.
 
-**When spawned as a subagent:** Prioritize loading `.local.md` zones. If zones are missing, refuse writes and report back — do not probe. If write permissions are denied, stop and report what you need. Do not work around denials with alternative write methods.
+**When spawned as a subagent:** Prioritize loading `.local.md` zones or deriving them from `_vault-profile.md` (see Initialization step 3). If both sources lack zones covering the target path, refuse with a clear `Archivist policy:` prefix message identifying what's missing — do not probe by attempting the write. If a write is denied at the tooling layer (Claude Code permission system, not your policy), stop and report what you need. Do not work around denials with alternative write methods.
 
 ### Subagent Input Volume Guard (defense-in-depth)
 
@@ -213,7 +223,9 @@ A well-formed briefing — file paths + operations (create / update / append / s
 
 **Read primitives are not fungible to the Write tool.** The Read tool, `obsidian read`, and the Write tool's internal read-first gate are three separate state machines. Write only honors its own Read. If the Read tool is denied on a path you intend to write, **do not attempt the write** — report and stop. Do not try to satisfy Write's gate via `obsidian read`.
 
-**Pre-flight refusal:** When `.local.md` is missing both `architect_write_zones` and `curator_write_zones`, and a write request targets a path not in `designated_output_zones`, **refuse up-front with a clear message** — do not attempt → fail → retry → report. Suggested phrasing: *"Writes to `<path>` are blocked because no write zones are configured in `.local.md`. Add `curator_write_zones:` (or `architect_write_zones:`) covering this path, or run vault profiling to discover zones."*
+**Pre-flight refusal:** When neither `.local.md` nor `_vault-profile.md`'s "Directory Trust Levels" provides zones covering the target path, **refuse up-front with a clear `Archivist policy:` prefix message** so users can distinguish your rule from Claude Code's permission system — do not attempt → fail → retry → report. Suggested phrasing: *"Archivist policy: writes to `<path>` are blocked because no write zones cover it. Either (a) add `curator_write_zones:` (or `architect_write_zones:`) to `.local.md`, (b) run vault profiling so the profile's Directory Trust Levels can be derived, or (c) move the operation to a covered zone."*
+
+**Disambiguating refusal vs Claude Code denial:** Always prefix policy-based refusals with `Archivist policy:`. Reserve bare "denied" / "permission denied" wording for actual Claude Code tooling-layer rejections. This lets the user diagnose at the right layer (your policy vs `~/.claude/settings.json` allow rules) without chasing the wrong root cause.
 
 ### When Read denials persist
 
@@ -486,7 +498,7 @@ Write only stable facts — not task state. Large diffs (50%+ sections changed):
 
 **`_vault-profile.md`:** Use section-based replacement only (see Session Learning). Never full-file overwrite.
 
-**No zones configured:** If `.local.md` is absent or zones are not set, default to confirming all writes and offer to run vault profiling to discover zones.
+**No zones configured:** When `.local.md` lacks zone fields, derive zones from `_vault-profile.md`'s "Directory Trust Levels" table per the mapping in Initialization step 3. Derived zones apply for the session and trigger a one-time offer to persist to `.local.md`. If the profile also lacks Directory Trust Levels, default to confirming all writes (top-level) or refusing with `Archivist policy:` prefix (subagent), and offer to run vault profiling to discover zones.
 
 ALWAYS ask user confirmation before:
 - Any write to structural zones (dry-run first, then confirm)

--- a/plugins/archivist/skills/vault-architect/SKILL.md
+++ b/plugins/archivist/skills/vault-architect/SKILL.md
@@ -317,9 +317,11 @@ Before writing to any path in the vault, check whether it falls within your allo
 
 **Out-of-zone writes:** If the target path does not match any architect zone, **refuse the write** and suggest using vault-curator instead. Example: "This path is in a curator-managed zone. Use vault-curator to modify note content."
 
-**No zones configured:** If `.local.md` has no zone fields, all writes require user confirmation (existing Bounded Autonomy behavior). Offer to run vault profiling to discover and configure zones.
+**No zones configured in `.local.md`:** The archivist agent's initialization derives zones from `_vault-profile.md`'s "Directory Trust Levels" table when present (mapping: `infrastructure` → `architect_write_zones`; `personal/guarded`/`project-scoped` → `curator_write_zones`; `automated/generated` → `designated_output_zones`). If derived zones cover the target, proceed (still with confirmation per architect tier). If neither `.local.md` nor the profile provides coverage, refuse with `Archivist policy:` prefix and offer to run vault profiling.
 
 **All writes require confirmation** — regardless of zone. The zone model determines *which skill* may write, not *whether* to confirm. Confirmation-free writes are deferred until hook-based enforcement is available.
+
+**Refusal phrasing:** Always prefix policy-based refusals with `Archivist policy:` to disambiguate from Claude Code tooling-layer permission denials. Never use bare "denied" wording for your own rules.
 
 <!-- v2 note: In future versions, this skill may run as an isolated subagent with restricted tools. Write boundaries documented here will become the subagent's tool restrictions. -->
 

--- a/plugins/archivist/skills/vault-curator/SKILL.md
+++ b/plugins/archivist/skills/vault-curator/SKILL.md
@@ -98,9 +98,11 @@ Do NOT attempt the operation, even partially.
 
 Check `curator_write_zones:` in `${CLAUDE_PLUGIN_ROOT}/.local.md` before any write. A write is allowed if the target path starts with a listed zone prefix. Canvas files and discovery views are always allowed as generated output regardless of zone.
 
-**Out-of-zone:** refuse and suggest vault-architect. **No zones configured:** confirm all writes and offer to run vault profiling.
+**Out-of-zone:** refuse with `Archivist policy:` prefix and suggest vault-architect. **No zones configured in `.local.md`:** the archivist agent's initialization derives zones from `_vault-profile.md`'s "Directory Trust Levels" table when present — if those derived zones cover the target path, proceed; otherwise refuse with `Archivist policy:` prefix and offer to run vault profiling.
 
 **All writes require confirmation** — the zone model determines *which skill* may write, not *whether* to confirm.
+
+**Refusal phrasing:** Always prefix policy-based refusals with `Archivist policy:` to disambiguate from Claude Code tooling-layer permission denials. Never use bare "denied" wording for your own rules.
 
 
 ### Meeting Extraction from Logs


### PR DESCRIPTION
## Summary

When `.local.md` lacks zone fields, the archivist agent now derives `architect_write_zones`, `curator_write_zones`, and `designated_output_zones` from `_vault-profile.md`'s "Directory Trust Levels" table — instead of blanket-refusing every write. Derived zones apply for the session with a one-time AskUserQuestion offer to persist them. All policy-based refusals now use an `Archivist policy:` prefix to disambiguate from Claude Code tooling-layer denials.

## Why

Today's session spent **~90 minutes** chasing what looked like a Claude Code subagent permission bug — settings.json edits, additionalDirectories audits, `defaultMode: acceptEdits` changes, deep research into known subagent inheritance bugs (#57118, #18950, #65918, #56854). Then empirical tests proved the tooling layer was never blocking:

| Test | Subagent | Target | Tooling result |
|---|---|---|---|
| A | general-purpose | `800 Generated/test.md` | ✓ Silent success |
| B | fresh archivist | `800 Generated/test.md` | ✓ Silent success |
| C | fresh archivist | `700 Notes/test.md` | ✓ Tooling silent, but archivist self-reported "I would have refused — `.local.md` doesn't exist → `700 Notes/` classified as Unknown zone → blanket refuse" |

**The archivist's own bounded-autonomy logic was the blocker, not Claude Code permissions.** The opaque "denied" wording sent debugging down the wrong rabbit hole entirely.

## Mapping

| Profile trust level | Maps to zone |
|---|---|
| `infrastructure` | `architect_write_zones` |
| `personal/guarded` or `project-scoped` | `curator_write_zones` |
| `automated/generated` | `designated_output_zones` |

Derived zones apply for the session. After derivation, a one-time AskUserQuestion (Yes / No / Customize) offers to persist to `.local.md` so future sessions skip the derivation step.

## Acceptance criteria

- [x] Curator writes to non-structural zones work without per-action confirmation when `.local.md` is absent but profile has trust levels
- [x] Architect-tier zones (templates, fileClasses, bases, canvases, `_vault-profile.md`) still confirm by default
- [x] Refusals say `Archivist policy:` not bare "denied" — three places + new disambiguation subsection
- [x] Auto-discovery from `_vault-profile.md` Directory Trust Levels in Init step 3

## Files changed (7)

- `agents/archivist.md` — 5 edits (init steps 2 & 3, write path subagent rule, pre-flight refusal, bounded autonomy "No zones configured")
- `skills/vault-curator/SKILL.md` — Write Boundaries + new Refusal phrasing rule
- `skills/vault-architect/SKILL.md` — Write Boundaries + new Refusal phrasing rule
- `README.md` — 3 version history rows (archivist 1.28.0, vault-curator 1.16.0, vault-architect 1.12.0)
- `plugin.json` — 1.27.0 → 1.28.0 (MINOR — new capability)
- `.agentsmith-baselines.json` — last_evaluated updated to 2026-06-08
- `marketplace.json` — synced

## Evaluation deltas

| Component | Before | After | Note |
|---|---|---|---|
| Agent archivist | 93/100 | 93/100 | Unchanged — substantive logic, evaluator measures example variety + length |
| Skill vault-curator | 96/100 | 96/100 | Conciseness 79→78 from added refusal-phrasing rule; overall held |
| Skill vault-architect | 94/100 | 93/100 | Conciseness 77→76; 1-pt regression accepted for consistency with agent |

## Explicitly NOT done

- ❌ **No MCP rearchitecture** — the deep-research initial recommendation assumed a Claude Code platform bug; empirical tests proved otherwise. MCP rearchitecture solves a problem we don't have.
- ❌ **No new frontmatter `permissionMode`/`hooks`/`mcpServers`** — explicitly forbidden for plugin-shipped agents ([plugins-reference docs](https://code.claude.com/docs/en/plugins-reference)).
- ❌ **No upstream Claude Code issue** — known subagent-inheritance bug class (#18950, #65918, #57118) is real but did NOT cause today's problem.

## Test plan — VALIDATED ✓

Validated in a fresh Claude session (tmux pane `Notes:1.2`) running 1.28.0 against vault `~/Documents/PAN_Projects/Notes` on 2026-06-08. All 6 items PASS.

- [x] Reinstall archivist plugin at v1.28.0 — staged via rsync into local cache
- [x] Fresh session in a vault that has `_vault-profile.md` with Directory Trust Levels but no `.local.md` — archivist offered scaffolding via `AskUserQuestion` with three options (Yes / No / Customize)
- [x] Curator writes to `700 Notes/` proceed after scaffolding without per-action confirmation — file `permission-test-v128-2026-06-08.md` created silently
- [x] Architect writes to `900 📐Templates/` still confirm — agent issued explicit confirmation question before any write
- [x] Trigger a refusal (write to a path not in any zone) — message starts with `Archivist policy:` and offers three remediation paths
- [x] Confirm `.local.md` persistence path: scaffolding offer captured verbatim; pre-flight refusal validated; `.local.md` not written so clean-install scenario is preserved for repeat tests

### Test 6 verbatim refusal (key artifact)

> Archivist policy: Writes to `RANDOM-UNZONED-DIR/test.md` are blocked because that path is not covered by any configured write zone. Derived zones for this session are: architect=[`100 Dashboards`, `900 Templates`, `Skills`, `_vault-profile.md`], curator=[`000 Pillars`, `300 Pipelines`, `500 Cycles`, `600 Projects`, `700 Notes`], generated=[`200 Canvases`, `800 Generated`, `Clippings`]. To proceed, either (a) choose a path inside one of these zones, or (b) add `RANDOM-UNZONED-DIR` to the appropriate zone in `.local.md`, or (c) update `_vault-profile.md`'s Directory Trust Levels table and re-derive.

Three remediation paths offered. Disambiguated from Claude Code's "denied" wording. Good UX — teaches the user the model rather than just blocking.

### Sidecar finding — non-blocking

Emoji-prefix drift discovered during Test 5: 4 of 11 vault directories carry emoji decorators on disk (`000 🏛 Pillars`, `300 🚰 Pipelines`, `500 ♽ Cycles`, `900 📐Templates`) while the `_vault-profile.md` Directory Trust Levels table lists them as plain names. Test 5 only passed because the validator's model *inferred* normalization from convention prose at line 53 of the profile — not from codified logic. That inference is non-deterministic; a different run could refuse the write entirely.

Not a PR blocker — the derivation faithfully reflects what's in the profile. Will be tracked as a follow-up issue post-merge.

### Validation surprise worth knowing

**Version-loading is per-spawn, not per-session.** When the cache was re-rsynced mid-session to pick up this PR's amendment commit, a freshly-spawned archivist subagent loaded the corrected source without requiring a Claude Code restart. Useful for iterative testing of unmerged plugin changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
